### PR TITLE
Add settings JSON export/import and reset capability

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -85,6 +85,8 @@ dependencies {
     implementation("androidx.compose.foundation:foundation-layout-android:1.6.0")
     implementation("androidx.games:games-activity:3.0.0")
     testImplementation("junit:junit:4.13.2")
+    testImplementation("androidx.test:core:1.5.0")
+    testImplementation("org.robolectric:robolectric:4.10.3")
     androidTestImplementation("androidx.test.ext:junit:1.1.5")
     androidTestImplementation("androidx.test.espresso:espresso-core:3.5.1")
     androidTestImplementation(platform("androidx.compose:compose-bom:2024.02.00"))

--- a/app/src/main/java/com/nervesparks/iris/data/UserPreferencesRepository.kt
+++ b/app/src/main/java/com/nervesparks/iris/data/UserPreferencesRepository.kt
@@ -208,6 +208,11 @@ class UserPreferencesRepository private constructor(context: Context) {
         return sharedPreferences.getBoolean(KEY_PERF_ENABLE_BACKGROUND_PROCESSING, true)
     }
 
+    // Clear all stored preferences
+    fun clearAll() {
+        sharedPreferences.edit().clear().apply()
+    }
+
     companion object {
         @Volatile
         private var INSTANCE: UserPreferencesRepository? = null

--- a/app/src/main/java/com/nervesparks/iris/data/repository/impl/SettingsRepositoryImpl.kt
+++ b/app/src/main/java/com/nervesparks/iris/data/repository/impl/SettingsRepositoryImpl.kt
@@ -1,16 +1,38 @@
 package com.nervesparks.iris.data.repository.impl
 
-import android.content.Context
 import android.util.Log
 import com.nervesparks.iris.data.UserPreferencesRepository
 import com.nervesparks.iris.data.repository.SettingsRepository
 import com.nervesparks.iris.data.repository.ThinkingTokenSettings
 import com.nervesparks.iris.data.repository.PerformanceSettings
 import com.nervesparks.iris.data.repository.UISettings
+import com.squareup.moshi.Moshi
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 
 import javax.inject.Inject
+
+private data class AllSettings(
+    val defaultModelName: String,
+    val huggingFaceToken: String,
+    val huggingFaceUsername: String,
+    val modelTemperature: Float,
+    val modelTopP: Float,
+    val modelTopK: Int,
+    val modelMaxTokens: Int,
+    val modelContextLength: Int,
+    val modelSystemPrompt: String,
+    val modelChatFormat: String,
+    val modelThreadCount: Int,
+    val showThinkingTokens: Boolean,
+    val thinkingTokenStyle: String,
+    val uiTheme: String,
+    val uiFontSize: Float,
+    val uiEnableAnimations: Boolean,
+    val uiEnableHapticFeedback: Boolean,
+    val perfEnableMemoryOptimization: Boolean,
+    val perfEnableBackgroundProcessing: Boolean
+)
 
 /**
  * Implementation of SettingsRepository using UserPreferencesRepository
@@ -74,8 +96,12 @@ class SettingsRepositoryImpl @Inject constructor(
     override suspend fun getPerformanceSettings(): PerformanceSettings {
         return withContext(Dispatchers.IO) {
             try {
-                // TODO: Implement actual performance settings loading
-                PerformanceSettings()
+                PerformanceSettings(
+                    threadCount = userPreferencesRepository.getModelThreadCount(),
+                    maxContextLength = userPreferencesRepository.getModelContextLength(),
+                    enableMemoryOptimization = userPreferencesRepository.getPerfEnableMemoryOptimization(),
+                    enableBackgroundProcessing = userPreferencesRepository.getPerfEnableBackgroundProcessing()
+                )
             } catch (e: Exception) {
                 Log.e(tag, "Error getting performance settings", e)
                 PerformanceSettings()
@@ -86,7 +112,10 @@ class SettingsRepositoryImpl @Inject constructor(
     override suspend fun savePerformanceSettings(settings: PerformanceSettings) {
         withContext(Dispatchers.IO) {
             try {
-                // TODO: Implement actual performance settings saving
+                userPreferencesRepository.setModelThreadCount(settings.threadCount)
+                userPreferencesRepository.setModelContextLength(settings.maxContextLength)
+                userPreferencesRepository.setPerfEnableMemoryOptimization(settings.enableMemoryOptimization)
+                userPreferencesRepository.setPerfEnableBackgroundProcessing(settings.enableBackgroundProcessing)
                 Log.d(tag, "Performance settings saved")
             } catch (e: Exception) {
                 Log.e(tag, "Error saving performance settings", e)
@@ -97,8 +126,12 @@ class SettingsRepositoryImpl @Inject constructor(
     override suspend fun getUISettings(): UISettings {
         return withContext(Dispatchers.IO) {
             try {
-                // TODO: Implement actual UI settings loading
-                UISettings()
+                UISettings(
+                    theme = userPreferencesRepository.getUITheme(),
+                    fontSize = userPreferencesRepository.getUIFontSize(),
+                    enableAnimations = userPreferencesRepository.getUIEnableAnimations(),
+                    enableHapticFeedback = userPreferencesRepository.getUIEnableHapticFeedback()
+                )
             } catch (e: Exception) {
                 Log.e(tag, "Error getting UI settings", e)
                 UISettings()
@@ -109,7 +142,10 @@ class SettingsRepositoryImpl @Inject constructor(
     override suspend fun saveUISettings(settings: UISettings) {
         withContext(Dispatchers.IO) {
             try {
-                // TODO: Implement actual UI settings saving
+                userPreferencesRepository.setUITheme(settings.theme)
+                userPreferencesRepository.setUIFontSize(settings.fontSize)
+                userPreferencesRepository.setUIEnableAnimations(settings.enableAnimations)
+                userPreferencesRepository.setUIEnableHapticFeedback(settings.enableHapticFeedback)
                 Log.d(tag, "UI settings saved")
             } catch (e: Exception) {
                 Log.e(tag, "Error saving UI settings", e)
@@ -120,8 +156,28 @@ class SettingsRepositoryImpl @Inject constructor(
     override suspend fun exportSettings(): String {
         return withContext(Dispatchers.IO) {
             try {
-                // TODO: Implement actual settings export to JSON
-                "{}"
+                val settings = AllSettings(
+                    defaultModelName = userPreferencesRepository.getDefaultModelName(),
+                    huggingFaceToken = userPreferencesRepository.getHuggingFaceToken(),
+                    huggingFaceUsername = userPreferencesRepository.getHuggingFaceUsername(),
+                    modelTemperature = userPreferencesRepository.getModelTemperature(),
+                    modelTopP = userPreferencesRepository.getModelTopP(),
+                    modelTopK = userPreferencesRepository.getModelTopK(),
+                    modelMaxTokens = userPreferencesRepository.getModelMaxTokens(),
+                    modelContextLength = userPreferencesRepository.getModelContextLength(),
+                    modelSystemPrompt = userPreferencesRepository.getModelSystemPrompt(),
+                    modelChatFormat = userPreferencesRepository.getModelChatFormat(),
+                    modelThreadCount = userPreferencesRepository.getModelThreadCount(),
+                    showThinkingTokens = userPreferencesRepository.getShowThinkingTokens(),
+                    thinkingTokenStyle = userPreferencesRepository.getThinkingTokenStyle(),
+                    uiTheme = userPreferencesRepository.getUITheme(),
+                    uiFontSize = userPreferencesRepository.getUIFontSize(),
+                    uiEnableAnimations = userPreferencesRepository.getUIEnableAnimations(),
+                    uiEnableHapticFeedback = userPreferencesRepository.getUIEnableHapticFeedback(),
+                    perfEnableMemoryOptimization = userPreferencesRepository.getPerfEnableMemoryOptimization(),
+                    perfEnableBackgroundProcessing = userPreferencesRepository.getPerfEnableBackgroundProcessing()
+                )
+                Moshi.Builder().build().adapter(AllSettings::class.java).toJson(settings)
             } catch (e: Exception) {
                 Log.e(tag, "Error exporting settings", e)
                 "{}"
@@ -132,7 +188,27 @@ class SettingsRepositoryImpl @Inject constructor(
     override suspend fun importSettings(json: String): Result<Unit> {
         return withContext(Dispatchers.IO) {
             try {
-                // TODO: Implement actual settings import from JSON
+                val adapter = Moshi.Builder().build().adapter(AllSettings::class.java)
+                val settings = adapter.fromJson(json) ?: return@withContext Result.failure(Exception("Invalid JSON"))
+                userPreferencesRepository.setDefaultModelName(settings.defaultModelName)
+                userPreferencesRepository.setHuggingFaceToken(settings.huggingFaceToken)
+                userPreferencesRepository.setHuggingFaceUsername(settings.huggingFaceUsername)
+                userPreferencesRepository.setModelTemperature(settings.modelTemperature)
+                userPreferencesRepository.setModelTopP(settings.modelTopP)
+                userPreferencesRepository.setModelTopK(settings.modelTopK)
+                userPreferencesRepository.setModelMaxTokens(settings.modelMaxTokens)
+                userPreferencesRepository.setModelContextLength(settings.modelContextLength)
+                userPreferencesRepository.setModelSystemPrompt(settings.modelSystemPrompt)
+                userPreferencesRepository.setModelChatFormat(settings.modelChatFormat)
+                userPreferencesRepository.setModelThreadCount(settings.modelThreadCount)
+                userPreferencesRepository.setShowThinkingTokens(settings.showThinkingTokens)
+                userPreferencesRepository.setThinkingTokenStyle(settings.thinkingTokenStyle)
+                userPreferencesRepository.setUITheme(settings.uiTheme)
+                userPreferencesRepository.setUIFontSize(settings.uiFontSize)
+                userPreferencesRepository.setUIEnableAnimations(settings.uiEnableAnimations)
+                userPreferencesRepository.setUIEnableHapticFeedback(settings.uiEnableHapticFeedback)
+                userPreferencesRepository.setPerfEnableMemoryOptimization(settings.perfEnableMemoryOptimization)
+                userPreferencesRepository.setPerfEnableBackgroundProcessing(settings.perfEnableBackgroundProcessing)
                 Log.d(tag, "Settings imported successfully")
                 Result.success(Unit)
             } catch (e: Exception) {
@@ -145,7 +221,7 @@ class SettingsRepositoryImpl @Inject constructor(
     override suspend fun resetToDefaults() {
         withContext(Dispatchers.IO) {
             try {
-                // TODO: Implement actual settings reset
+                userPreferencesRepository.clearAll()
                 Log.d(tag, "Settings reset to defaults")
             } catch (e: Exception) {
                 Log.e(tag, "Error resetting settings", e)

--- a/app/src/test/java/com/nervesparks/iris/data/repository/impl/SettingsRepositoryImplTest.kt
+++ b/app/src/test/java/com/nervesparks/iris/data/repository/impl/SettingsRepositoryImplTest.kt
@@ -1,0 +1,137 @@
+package com.nervesparks.iris.data.repository.impl
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import com.nervesparks.iris.data.UserPreferencesRepository
+import com.nervesparks.iris.data.repository.PerformanceSettings
+import com.nervesparks.iris.data.repository.ThinkingTokenSettings
+import com.nervesparks.iris.data.repository.UISettings
+import kotlinx.coroutines.runBlocking
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class SettingsRepositoryImplTest {
+
+    private lateinit var context: Context
+    private lateinit var userPrefs: UserPreferencesRepository
+    private lateinit var repository: SettingsRepositoryImpl
+
+    @Before
+    fun setup() {
+        context = ApplicationProvider.getApplicationContext()
+        userPrefs = UserPreferencesRepository.getInstance(context)
+        userPrefs.clearAll()
+        repository = SettingsRepositoryImpl(userPrefs)
+    }
+
+    @After
+    fun tearDown() {
+        userPrefs.clearAll()
+    }
+
+    @Test
+    fun performanceSettingsRoundTrip() = runBlocking {
+        val settings = PerformanceSettings(
+            threadCount = 6,
+            maxContextLength = 2048,
+            enableMemoryOptimization = false,
+            enableBackgroundProcessing = false
+        )
+        repository.savePerformanceSettings(settings)
+        val loaded = repository.getPerformanceSettings()
+        assertEquals(settings, loaded)
+    }
+
+    @Test
+    fun uiSettingsRoundTrip() = runBlocking {
+        val settings = UISettings(
+            theme = "LIGHT",
+            fontSize = 1.5f,
+            enableAnimations = false,
+            enableHapticFeedback = false
+        )
+        repository.saveUISettings(settings)
+        val loaded = repository.getUISettings()
+        assertEquals(settings, loaded)
+    }
+
+    @Test
+    fun exportImportRoundTrip() = runBlocking {
+        val defaultModelName = "modelX"
+        val thinking = ThinkingTokenSettings(false, "ALWAYS_VISIBLE")
+        val perf = PerformanceSettings(
+            threadCount = 6,
+            maxContextLength = 2048,
+            enableMemoryOptimization = false,
+            enableBackgroundProcessing = false
+        )
+        val ui = UISettings(
+            theme = "LIGHT",
+            fontSize = 1.5f,
+            enableAnimations = false,
+            enableHapticFeedback = false
+        )
+
+        repository.setDefaultModelName(defaultModelName)
+        repository.saveThinkingTokenSettings(thinking)
+        repository.savePerformanceSettings(perf)
+        repository.saveUISettings(ui)
+
+        val json = repository.exportSettings()
+        repository.resetToDefaults()
+        repository.importSettings(json)
+
+        assertEquals(defaultModelName, repository.getDefaultModelName())
+        assertEquals(thinking, repository.getThinkingTokenSettings())
+        assertEquals(perf, repository.getPerformanceSettings())
+        assertEquals(ui, repository.getUISettings())
+    }
+
+    @Test
+    fun resetToDefaultsClearsPreferences() = runBlocking {
+        repository.savePerformanceSettings(
+            PerformanceSettings(
+                threadCount = 6,
+                maxContextLength = 2048,
+                enableMemoryOptimization = false,
+                enableBackgroundProcessing = false
+            )
+        )
+        repository.saveUISettings(
+            UISettings(
+                theme = "LIGHT",
+                fontSize = 1.5f,
+                enableAnimations = false,
+                enableHapticFeedback = false
+            )
+        )
+        repository.resetToDefaults()
+
+        val perf = repository.getPerformanceSettings()
+        val ui = repository.getUISettings()
+
+        assertEquals(
+            PerformanceSettings(
+                threadCount = 4,
+                maxContextLength = 4096,
+                enableMemoryOptimization = true,
+                enableBackgroundProcessing = true
+            ),
+            perf
+        )
+        assertEquals(
+            UISettings(
+                theme = "DARK",
+                fontSize = 1.0f,
+                enableAnimations = true,
+                enableHapticFeedback = true
+            ),
+            ui
+        )
+    }
+}


### PR DESCRIPTION
## Summary
- map UI and performance settings to UserPreferencesRepository
- support full settings export/import via Moshi
- add reset routine and unit tests validating round trips

## Testing
- `./gradlew test` *(fails: java.net.SocketException while fetching Robolectric artifacts)*

------
https://chatgpt.com/codex/tasks/task_e_6891423df2f88323a41eefe735322695