### PR TITLE
feat: cache remote model catalogue

### DIFF
--- a/app/src/main/java/com/nervesparks/iris/MainViewModel.kt
+++ b/app/src/main/java/com/nervesparks/iris/MainViewModel.kt
@@ -38,6 +38,7 @@ class MainViewModel @Inject constructor(
     private val llamaAndroid: LLamaAndroid,
     private val userPreferencesRepository: UserPreferencesRepository,
     private val chatRepository: ChatRepository,
+    private val modelRepository: com.nervesparks.iris.data.repository.ModelRepository,
     private val huggingFaceApiService: com.nervesparks.iris.data.HuggingFaceApiService,
     application: Application
 ) : AndroidViewModel(application) {
@@ -90,6 +91,9 @@ class MainViewModel @Inject constructor(
         loadDefaultModelName()
         loadModelSettings()
         loadThinkingTokenSettings()
+        viewModelScope.launch {
+            allModels = modelRepository.refreshAvailableModels()
+        }
     }
     private fun loadDefaultModelName(){
         try {
@@ -122,35 +126,7 @@ class MainViewModel @Inject constructor(
     var topK by mutableStateOf(40)
     var temp by mutableStateOf(0.7f)
 
-    var allModels by mutableStateOf(
-        listOf(
-            mapOf(
-                "name" to "Llama-3.2-3B-Instruct-Q4_K_L.gguf",
-                "source" to "https://huggingface.co/bartowski/Llama-3.2-3B-Instruct-GGUF/resolve/main/Llama-3.2-3B-Instruct-Q4_K_L.gguf?download=true",
-                "destination" to "Llama-3.2-3B-Instruct-Q4_K_L.gguf"
-            ),
-            mapOf(
-                "name" to "Llama-3.2-1B-Instruct-Q6_K_L.gguf",
-                "source" to "https://huggingface.co/bartowski/Llama-3.2-1B-Instruct-GGUF/resolve/main/Llama-3.2-1B-Instruct-Q6_K_L.gguf?download=true",
-                "destination" to "Llama-3.2-1B-Instruct-Q6_K_L.gguf"
-            ),
-            mapOf(
-                "name" to "stablelm-2-1_6b-chat.Q4_K_M.imx.gguf",
-                "source" to "https://huggingface.co/Crataco/stablelm-2-1_6b-chat-imatrix-GGUF/resolve/main/stablelm-2-1_6b-chat.Q4_K_M.imx.gguf?download=true",
-                "destination" to "stablelm-2-1_6b-chat.Q4_K_M.imx.gguf"
-            ),
-            mapOf(
-                "name" to "NemoTron-1.5B-Q4_K_M.gguf",
-                "source" to "https://huggingface.co/bartowski/nvidia_OpenReasoning-Nemotron-1.5B-GGUF/resolve/main/nvidia_OpenReasoning-Nemotron-1.5B-Q4_K_M.gguf?download=true",
-                "destination" to "NemoTron-1.5B-Q4_K_M.gguf"
-            ),
-            mapOf(
-                "name" to "Qwen_Qwen3-0.6B-Q4_K_M.gguf",
-                "source" to "https://huggingface.co/bartowski/Qwen_Qwen3-0.6B-GGUF/resolve/main/Qwen_Qwen3-0.6B-Q4_K_M.gguf?download=true",
-                "destination" to "Qwen_Qwen3-0.6B-Q4_K_M.gguf"
-            )
-        )
-    )
+    var allModels by mutableStateOf<List<Map<String, String>>>(emptyList())
 
     private var first by mutableStateOf(
         true

--- a/app/src/main/java/com/nervesparks/iris/data/UserPreferencesRepository.kt
+++ b/app/src/main/java/com/nervesparks/iris/data/UserPreferencesRepository.kt
@@ -1,6 +1,7 @@
 package com.nervesparks.iris.data
 
 import android.content.Context
+import com.nervesparks.iris.data.repository.ModelConfiguration
 
 private const val USER_PREFERENCES_NAME = "user_preferences"
 private const val KEY_DEFAULT_MODEL_NAME = "default_model_name"
@@ -16,6 +17,8 @@ private const val KEY_MODEL_CONTEXT_LENGTH = "model_context_length"
 private const val KEY_MODEL_SYSTEM_PROMPT = "model_system_prompt"
 private const val KEY_MODEL_CHAT_FORMAT = "model_chat_format"
 private const val KEY_MODEL_THREAD_COUNT = "model_thread_count"
+private const val KEY_CACHED_MODELS = "cached_models"
+private const val KEY_MODEL_CONFIG_PREFIX = "model_config_"
 
 // Thinking token settings keys
 private const val KEY_SHOW_THINKING_TOKENS = "show_thinking_tokens"
@@ -139,6 +142,40 @@ class UserPreferencesRepository private constructor(context: Context) {
 
     fun getModelThreadCount(): Int {
         return sharedPreferences.getInt(KEY_MODEL_THREAD_COUNT, 4)
+    }
+
+    // Per-model configuration
+    fun getModelConfiguration(modelName: String): ModelConfiguration {
+        val prefix = "${KEY_MODEL_CONFIG_PREFIX}${modelName}_"
+        return ModelConfiguration(
+            temperature = sharedPreferences.getFloat(prefix + "temperature", 0.7f),
+            topP = sharedPreferences.getFloat(prefix + "top_p", 0.9f),
+            topK = sharedPreferences.getInt(prefix + "top_k", 40),
+            threadCount = sharedPreferences.getInt(prefix + "thread_count", 2),
+            contextLength = sharedPreferences.getInt(prefix + "context_length", 4096),
+            systemPrompt = sharedPreferences.getString(prefix + "system_prompt", "") ?: ""
+        )
+    }
+
+    fun saveModelConfiguration(modelName: String, config: ModelConfiguration) {
+        val prefix = "${KEY_MODEL_CONFIG_PREFIX}${modelName}_"
+        sharedPreferences.edit().apply {
+            putFloat(prefix + "temperature", config.temperature)
+            putFloat(prefix + "top_p", config.topP)
+            putInt(prefix + "top_k", config.topK)
+            putInt(prefix + "thread_count", config.threadCount)
+            putInt(prefix + "context_length", config.contextLength)
+            putString(prefix + "system_prompt", config.systemPrompt)
+            apply()
+        }
+    }
+
+    fun getCachedModels(): String {
+        return sharedPreferences.getString(KEY_CACHED_MODELS, "") ?: ""
+    }
+
+    fun setCachedModels(json: String) {
+        sharedPreferences.edit().putString(KEY_CACHED_MODELS, json).apply()
     }
 
     // Thinking token settings

--- a/app/src/main/java/com/nervesparks/iris/data/repository/ModelRepository.kt
+++ b/app/src/main/java/com/nervesparks/iris/data/repository/ModelRepository.kt
@@ -11,6 +11,11 @@ interface ModelRepository {
      * Get all available models from the specified directory
      */
     suspend fun getAvailableModels(directory: File): List<Map<String, String>>
+
+    /**
+     * Refresh the model catalogue from remote or local storage and cache the results
+     */
+    suspend fun refreshAvailableModels(): List<Map<String, String>>
     
     /**
      * Load a model by file path


### PR DESCRIPTION
## Summary
- fetch model catalogue through HuggingFace API and cache results
- persist per-model configuration using shared preferences
- expose repository refresh method and initialize catalogue in `MainViewModel`

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6891423b9ff88323b960c097d6808575