### PR TITLE
refactor: use repositories for model and settings

### DIFF
--- a/app/src/main/java/com/nervesparks/iris/MainActivity.kt
+++ b/app/src/main/java/com/nervesparks/iris/MainActivity.kt
@@ -63,7 +63,6 @@ import androidx.compose.foundation.BorderStroke
 import android.app.Application
 import androidx.compose.foundation.border
 import androidx.activity.viewModels
-import com.nervesparks.iris.data.UserPreferencesRepository
 import com.nervesparks.iris.ui.SettingsBottomSheet
 import com.nervesparks.iris.ui.theme.IrisStarTheme
 import com.nervesparks.iris.ui.ChatListScreen

--- a/app/src/main/java/com/nervesparks/iris/ui/SearchResultScreen.kt
+++ b/app/src/main/java/com/nervesparks/iris/ui/SearchResultScreen.kt
@@ -50,7 +50,6 @@ import androidx.compose.ui.unit.sp
 import com.nervesparks.iris.MainViewModel
 import com.nervesparks.iris.R
 import com.nervesparks.iris.data.HuggingFaceApiService
-import com.nervesparks.iris.data.UserPreferencesRepository
 import com.nervesparks.iris.ui.components.InfoModal
 import com.nervesparks.iris.ui.components.LoadingModal
 import com.nervesparks.iris.ui.components.ModelCard

--- a/app/src/main/java/com/nervesparks/iris/ui/components/DownloadModal.kt
+++ b/app/src/main/java/com/nervesparks/iris/ui/components/DownloadModal.kt
@@ -26,7 +26,6 @@ import androidx.compose.ui.window.Dialog
 import com.nervesparks.iris.Downloadable
 import com.nervesparks.iris.MainViewModel
 import com.nervesparks.iris.data.HuggingFaceApiService
-import com.nervesparks.iris.data.UserPreferencesRepository
 import kotlinx.coroutines.launch
 
 @Composable


### PR DESCRIPTION
## Summary
- inject ModelRepository and SettingsRepository into MainViewModel
- delegate default model name and thinking token settings to SettingsRepository
- fetch available models from ModelRepository instead of hardcoded list

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6891423f99b48323bb7d2f501c7a65c8