### PR TITLE
Use MaterialTheme colors across UI components

### DIFF
--- a/app/src/main/java/com/nervesparks/iris/ui/SettingsScreen.kt
+++ b/app/src/main/java/com/nervesparks/iris/ui/SettingsScreen.kt
@@ -53,7 +53,7 @@ fun SettingsScreen(
     Column(
         modifier = Modifier
             .fillMaxSize()
-            .background(Color(0xFF0F1419))
+            .background(MaterialTheme.colorScheme.background)
             .verticalScroll(rememberScrollState())
             .padding(16.dp),
         verticalArrangement = Arrangement.spacedBy(16.dp)
@@ -62,7 +62,7 @@ fun SettingsScreen(
         Card(
             modifier = Modifier.fillMaxWidth(),
             colors = CardDefaults.cardColors(
-                containerColor = Color(0xFF1E2328)
+                containerColor = MaterialTheme.colorScheme.surfaceVariant
             ),
             shape = RoundedCornerShape(12.dp)
         ) {
@@ -191,7 +191,7 @@ fun SettingsScreen(
         Card(
             modifier = Modifier.fillMaxWidth(),
             colors = CardDefaults.cardColors(
-                containerColor = Color(0xFF1E2328)
+                containerColor = MaterialTheme.colorScheme.surfaceVariant
             ),
             shape = RoundedCornerShape(12.dp)
         ) {
@@ -229,7 +229,7 @@ fun SettingsScreen(
         Card(
             modifier = Modifier.fillMaxWidth(),
             colors = CardDefaults.cardColors(
-                containerColor = Color(0xFF1E2328)
+                containerColor = MaterialTheme.colorScheme.surfaceVariant
             ),
             shape = RoundedCornerShape(12.dp)
         ) {
@@ -273,7 +273,7 @@ fun SettingsScreen(
         Card(
             modifier = Modifier.fillMaxWidth(),
             colors = CardDefaults.cardColors(
-                containerColor = Color(0xFF1E2328)
+                containerColor = MaterialTheme.colorScheme.surfaceVariant
             ),
             shape = RoundedCornerShape(12.dp)
         ) {

--- a/app/src/main/java/com/nervesparks/iris/ui/components/ChatSection.kt
+++ b/app/src/main/java/com/nervesparks/iris/ui/components/ChatSection.kt
@@ -143,7 +143,7 @@ private fun UserOrAssistantMessage(role: String, message: String, onLongClick: (
             modifier = Modifier
                 .padding(horizontal = 2.dp)
                 .background(
-                    color = if (role == "user") Color(0xFF171E2C) else Color(0xFF1E293B),
+                    color = if (role == "user") MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.surfaceVariant,
                     shape = RoundedCornerShape(16.dp)
                 )
                 .combinedClickable(
@@ -155,7 +155,7 @@ private fun UserOrAssistantMessage(role: String, message: String, onLongClick: (
             Text(
                 text = message.removePrefix("```"),
                 style = MaterialTheme.typography.bodyMedium,
-                color = Color.White,
+                color = if (role == "user") MaterialTheme.colorScheme.onPrimary else MaterialTheme.colorScheme.onSurface,
                 lineHeight = 22.sp
             )
         }

--- a/app/src/main/java/com/nervesparks/iris/ui/components/ModelCard.kt
+++ b/app/src/main/java/com/nervesparks/iris/ui/components/ModelCard.kt
@@ -52,8 +52,8 @@ fun ModelCard(
                 shape = RoundedCornerShape(8.dp)
             ),
         colors = CardDefaults.cardColors(
-            containerColor = Color(0xff0f172a),
-            contentColor = Color.White
+            containerColor = MaterialTheme.colorScheme.surfaceVariant,
+            contentColor = MaterialTheme.colorScheme.onSurfaceVariant
         ),
         elevation = CardDefaults.cardElevation(defaultElevation = 4.dp)
     ) {


### PR DESCRIPTION
## Summary
- derive SettingsScreen background and cards from `MaterialTheme.colorScheme`
- theme chat bubbles with primary/surface colors and matching text
- apply semantic surface colors to ModelCard

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68922637f3bc8323aa0bc95c8a5e6057