### PR TITLE
Refactor prompt sources and externalize UI strings

### DIFF
--- a/app/src/main/java/com/nervesparks/iris/MainViewModel.kt
+++ b/app/src/main/java/com/nervesparks/iris/MainViewModel.kt
@@ -32,6 +32,7 @@ import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
 
 import kotlinx.coroutines.flow.first
+import com.nervesparks.iris.R
 
 @HiltViewModel
 class MainViewModel @Inject constructor(
@@ -91,6 +92,8 @@ class MainViewModel @Inject constructor(
         loadDefaultModelName()
         loadModelSettings()
         loadThinkingTokenSettings()
+        promptSuggestions = application.resources.getStringArray(R.array.prompt_suggestions).toList()
+        homePrompts = application.resources.getStringArray(R.array.home_prompts).toList()
         viewModelScope.launch {
             allModels = modelRepository.refreshAvailableModels()
         }
@@ -145,6 +148,11 @@ class MainViewModel @Inject constructor(
         private set
 
     var eot_str = ""
+
+    var promptSuggestions by mutableStateOf<List<String>>(emptyList())
+        private set
+    var homePrompts by mutableStateOf<List<String>>(emptyList())
+        private set
 
     // Quick action and attachment handlers
     var lastQuickAction by mutableStateOf<String?>(null)

--- a/app/src/main/java/com/nervesparks/iris/ui/MainChatScreen.kt
+++ b/app/src/main/java/com/nervesparks/iris/ui/MainChatScreen.kt
@@ -169,26 +169,8 @@ fun MainChatScreen (
     val windowInsets = WindowInsets.ime
     val focusManager = LocalFocusManager.current
     println("Thread started: ${Thread.currentThread().name}")
-    val Prompts = listOf(
-        "Explain how to develop a consistent reading habit.",
-        "Write an email to your manager requesting leave for a day.",
-        "Suggest time management strategies for handling multiple deadlines effectively.",
-        "Draft a professional LinkedIn message to connect with a recruiter.",
-        "Suggest ways to practice mindfulness in a busy daily schedule.",
-        "Recommend a 15-minute daily workout routine to stay fit with a busy schedule.",
-        "Provide a simple and polite Spanish translation of 'Excuse me, can you help me?' with explanation.",
-        "List the top 5 science fiction novels that have most influenced modern technological thinking",
-        "List security tips to protect personal information online.",
-        "Recommend three books that can improve communication skills."
-    )
-
+    val prompts = viewModel.promptSuggestions
     val allModelsExist = models.all { model -> model.destination.exists() }
-    val Prompts_Home = listOf(
-        "Explains complex topics simply.",
-        "Remembers previous inputs.",
-        "May sometimes be inaccurate.",
-        "Unable to provide current affairs due to no internet connectivity."
-    )
     var recognizedText by remember { mutableStateOf("") }
     val speechRecognizerLauncher = rememberLauncherForActivityResult(contract = ActivityResultContracts.StartActivityForResult()) {
             result ->
@@ -711,13 +693,13 @@ fun MainChatScreen (
                         horizontalArrangement = Arrangement.spacedBy(4.dp), // Reduced space between cards
                         contentPadding = PaddingValues(vertical = 8.dp)
                     ) {
-                        items(Prompts.size) { index ->
+                        items(prompts.size) { index ->
                             if(viewModel.messages.size <= 1){
                                 Card(
                                     modifier = Modifier
                                         .height(100.dp)
                                         .clickable {
-                                            viewModel.updateMessage(Prompts[index])
+                                            viewModel.updateMessage(prompts[index])
                                             focusRequester.requestFocus()
                                         }
                                         .padding(horizontal = 8.dp),
@@ -726,7 +708,7 @@ fun MainChatScreen (
                                 ) {
 
                                     Text(
-                                        text = Prompts[index],
+                                        text = prompts[index],
                                         style = MaterialTheme.typography.bodySmall.copy(
                                             color = MaterialTheme.colorScheme.onSurfaceVariant,
                                             fontSize = 12.sp,

--- a/app/src/main/java/com/nervesparks/iris/ui/components/ModernChatInput.kt
+++ b/app/src/main/java/com/nervesparks/iris/ui/components/ModernChatInput.kt
@@ -28,6 +28,8 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
+import androidx.compose.ui.res.stringResource
+import com.nervesparks.iris.R
 import com.nervesparks.iris.ui.theme.*
 
 /**
@@ -49,7 +51,7 @@ fun ModernChatInput(
     onPhotosClick: () -> Unit = {},
     onFilesClick: () -> Unit = {},
     modifier: Modifier = Modifier,
-    placeholder: String = "Ask anything",
+    placeholder: String? = null,
     enabled: Boolean = true
 ) {
     val context = LocalContext.current
@@ -97,7 +99,7 @@ fun ModernChatInput(
             ) {
                 Icon(
                     imageVector = Icons.Default.Add,
-                    contentDescription = "Attach",
+                    contentDescription = stringResource(R.string.attach),
                     tint = MaterialTheme.colorScheme.onSurface,
                     modifier = Modifier.size(20.dp)
                 )
@@ -127,7 +129,7 @@ fun ModernChatInput(
                 decorationBox = { innerTextField ->
                     if (value.isEmpty()) {
                         Text(
-                            text = placeholder,
+                            text = placeholder ?: stringResource(R.string.prompt_placeholder),
                             style = TextStyle(
                                 color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.6f),
                                 fontSize = 16.sp
@@ -145,7 +147,7 @@ fun ModernChatInput(
             ) {
                 Icon(
                     imageVector = Icons.Default.Add,
-                    contentDescription = "Voice Input",
+                    contentDescription = stringResource(R.string.voice_input),
                     tint = MaterialTheme.colorScheme.onSurface,
                     modifier = Modifier.size(20.dp)
                 )
@@ -179,19 +181,19 @@ private fun QuickActionsRow(
     ) {
         QuickActionButton(
             icon = Icons.Default.Info,
-            text = "Latest news",
+            text = stringResource(R.string.quick_action_latest_news),
             onClick = onLatestNews
         )
-        
+
         QuickActionButton(
             icon = Icons.Default.Add,
-            text = "Create images",
+            text = stringResource(R.string.quick_action_create_images),
             onClick = onCreateImages
         )
-        
+
         QuickActionButton(
             icon = Icons.Default.Edit,
-            text = "Cartoon style",
+            text = stringResource(R.string.quick_action_cartoon_style),
             onClick = onCartoonStyle
         )
     }
@@ -276,36 +278,36 @@ private fun AttachmentDialog(
                 modifier = Modifier.padding(16.dp)
             ) {
                 Text(
-                    text = "Choose attachment",
+                    text = stringResource(R.string.choose_attachment),
                     style = MaterialTheme.typography.titleMedium,
                     color = MaterialTheme.colorScheme.onSurface,
                     modifier = Modifier.padding(bottom = 16.dp)
                 )
-                
+
                 // Camera option
                 AttachmentOption(
                     icon = Icons.Default.Add,
-                    text = "Camera",
+                    text = stringResource(R.string.camera),
                     onClick = {
                         onCameraClick()
                         onDismiss()
                     }
                 )
-                
+
                 // Photos option
                 AttachmentOption(
                     icon = Icons.Default.Add,
-                    text = "Photos",
+                    text = stringResource(R.string.photos),
                     onClick = {
                         onPhotosClick()
                         onDismiss()
                     }
                 )
-                
+
                 // Files option
                 AttachmentOption(
                     icon = Icons.Default.Add,
-                    text = "Files",
+                    text = stringResource(R.string.files),
                     onClick = {
                         onFilesClick()
                         onDismiss()

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -9,4 +9,34 @@
     <string name="about_screen_title">About</string>
     <string name="benchmark_screen_title">BenchMark</string>
     <string name="refresh_button">Refresh</string>
+    <string name="prompt_placeholder">Ask anything</string>
+    <string name="quick_action_latest_news">Latest news</string>
+    <string name="quick_action_create_images">Create images</string>
+    <string name="quick_action_cartoon_style">Cartoon style</string>
+    <string name="attach">Attach</string>
+    <string name="voice_input">Voice Input</string>
+    <string name="choose_attachment">Choose attachment</string>
+    <string name="camera">Camera</string>
+    <string name="photos">Photos</string>
+    <string name="files">Files</string>
+
+    <string-array name="prompt_suggestions">
+        <item>Explain how to develop a consistent reading habit.</item>
+        <item>Write an email to your manager requesting leave for a day.</item>
+        <item>Suggest time management strategies for handling multiple deadlines effectively.</item>
+        <item>Draft a professional LinkedIn message to connect with a recruiter.</item>
+        <item>Suggest ways to practice mindfulness in a busy daily schedule.</item>
+        <item>Recommend a 15-minute daily workout routine to stay fit with a busy schedule.</item>
+        <item>Provide a simple and polite Spanish translation of 'Excuse me, can you help me?' with explanation.</item>
+        <item>List the top 5 science fiction novels that have most influenced modern technological thinking</item>
+        <item>List security tips to protect personal information online.</item>
+        <item>Recommend three books that can improve communication skills.</item>
+    </string-array>
+
+    <string-array name="home_prompts">
+        <item>Explains complex topics simply.</item>
+        <item>Remembers previous inputs.</item>
+        <item>May sometimes be inaccurate.</item>
+        <item>Unable to provide current affairs due to no internet connectivity.</item>
+    </string-array>
 </resources>


### PR DESCRIPTION
## Summary
- Move hard-coded prompt suggestions into `MainViewModel` state loaded from resources
- Replace inline UI text with Android string resources and resource-backed arrays
- Update chat input to use resource strings for quick actions and attachment labels

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_689231151db483239f22e60ef25740ce