### PR TITLE
feat: migrate UI components to Material3

### DIFF
--- a/app/src/main/java/com/nervesparks/iris/ui/MainChatScreen.kt
+++ b/app/src/main/java/com/nervesparks/iris/ui/MainChatScreen.kt
@@ -46,10 +46,10 @@ import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.selection.SelectionContainer
-import androidx.compose.material.DropdownMenu
-import androidx.compose.material.DropdownMenuItem
-import androidx.compose.material.Slider
-import androidx.compose.material.SliderDefaults
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.Slider
+import androidx.compose.material3.SliderDefaults
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.KeyboardArrowDown
 import androidx.compose.material.icons.filled.KeyboardArrowUp

--- a/app/src/main/java/com/nervesparks/iris/ui/ModelsScreen.kt
+++ b/app/src/main/java/com/nervesparks/iris/ui/ModelsScreen.kt
@@ -13,7 +13,7 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
-import androidx.compose.material.TabRowDefaults.Divider
+import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
@@ -82,7 +82,7 @@ fun ModelsScreen(extFileDir: File?, viewModel: MainViewModel, onSearchResultButt
                             tint = MaterialTheme.colorScheme.onSurface,
                         )
                     }
-                    Divider(
+                    HorizontalDivider(
                         modifier = Modifier
                             .fillMaxWidth(),
                         color = MaterialTheme.colorScheme.outline, // Set the color of the divider
@@ -116,7 +116,7 @@ fun ModelsScreen(extFileDir: File?, viewModel: MainViewModel, onSearchResultButt
                 }
             }
             item {
-                Divider(
+                HorizontalDivider(
                     modifier = Modifier
                         .fillMaxWidth(),
                     color = MaterialTheme.colorScheme.outline, // Set the color of the divider

--- a/app/src/main/java/com/nervesparks/iris/ui/components/DownloadInfoModal.kt
+++ b/app/src/main/java/com/nervesparks/iris/ui/components/DownloadInfoModal.kt
@@ -44,7 +44,7 @@ fun InfoModal(
                         modifier = Modifier.padding(bottom = 16.dp)
                     )
 
-                    Divider(
+                    HorizontalDivider(
                         modifier = Modifier.padding(vertical = 8.dp),
                         color = Color.LightGray.copy(alpha = 0.2f)
                     )

--- a/app/src/main/java/com/nervesparks/iris/ui/theme/Typography.kt
+++ b/app/src/main/java/com/nervesparks/iris/ui/theme/Typography.kt
@@ -1,34 +1,6 @@
 package com.nervesparks.iris.ui.theme
 
 import androidx.compose.material3.Typography
-import androidx.compose.ui.text.TextStyle
-import androidx.compose.ui.text.font.FontFamily
-import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.unit.sp
 
-// Set of Material typography styles to start with
-val AppTypography = Typography(
-    bodyLarge = TextStyle(
-        fontFamily = FontFamily.Default,
-        fontWeight = FontWeight.Normal,
-        fontSize = 16.sp,
-        lineHeight = 24.sp,
-        letterSpacing = 0.5.sp
-    )
-    /* Other default text styles to override
-    titleLarge = TextStyle(
-        fontFamily = FontFamily.Default,
-        fontWeight = FontWeight.Normal,
-        fontSize = 22.sp,
-        lineHeight = 28.sp,
-        letterSpacing = 0.sp
-    ),
-    labelSmall = TextStyle(
-        fontFamily = FontFamily.Default,
-        fontWeight = FontWeight.Medium,
-        fontSize = 11.sp,
-        lineHeight = 16.sp,
-        letterSpacing = 0.5.sp
-    )
-    */
-)
+// Use Material3 default typography
+val AppTypography = Typography()


### PR DESCRIPTION
## Summary
- Replace remaining Material2 `DropdownMenu` and `Slider` with Material3 versions
- Swap old `Divider` usages for `HorizontalDivider`
- Simplify typography to rely on Material3 defaults

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_689230fe70f88323be0503d40a85670e