### PR TITLE
Rename MarkdownText component and update references

### DIFF
--- a/app/src/main/java/com/nervesparks/iris/ui/MainChatScreen.kt
+++ b/app/src/main/java/com/nervesparks/iris/ui/MainChatScreen.kt
@@ -135,7 +135,7 @@ import com.nervesparks.iris.ui.components.LoadingModal
 import com.nervesparks.iris.ui.components.PerformanceMonitor
 import com.nervesparks.iris.ui.components.ModelSettingsScreen
 import com.nervesparks.iris.ui.components.ModelSelectionModal
-import com.nervesparks.iris.ui.components.MarkdownTextComponent
+import com.nervesparks.iris.ui.components.MarkdownText
 import com.nervesparks.iris.ui.components.MemoryManager
 
 import kotlinx.coroutines.launch
@@ -582,7 +582,7 @@ fun MainChatScreen (
                                                             }
                                                         )
                                                     ) {
-                                                        MarkdownTextComponent(
+                                                        MarkdownText(
                                                             markdown = if (trimmedMessage.startsWith("```")) {
                                                                 trimmedMessage.substring(3)
                                                             } else {
@@ -669,7 +669,7 @@ fun MainChatScreen (
                                                     ) {
                                                         // Previous content here
                                                     }
-                                                    MarkdownTextComponent(
+                                                    MarkdownText(
                                                         markdown = if (trimmedMessage.startsWith("```")) {
                                                             trimmedMessage.substring(3)
                                                         } else {

--- a/app/src/main/java/com/nervesparks/iris/ui/components/MarkdownText.kt
+++ b/app/src/main/java/com/nervesparks/iris/ui/components/MarkdownText.kt
@@ -6,15 +6,15 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.sp
-import dev.jeziellago.compose.markdowntext.MarkdownText
+import dev.jeziellago.compose.markdowntext.MarkdownText as CoreMarkdownText
 
 @Composable
-fun MarkdownTextComponent(
+fun MarkdownText(
     markdown: String,
     modifier: Modifier = Modifier,
     textAlign: TextAlign = TextAlign.Start
 ) {
-    MarkdownText(
+    CoreMarkdownText(
         markdown = markdown,
         modifier = modifier.fillMaxWidth(),
         color = MaterialTheme.colorScheme.onSurface,
@@ -22,4 +22,4 @@ fun MarkdownTextComponent(
         textAlign = textAlign,
         style = MaterialTheme.typography.bodyMedium
     )
-} 
+}

--- a/app/src/main/java/com/nervesparks/iris/ui/components/ThinkingMessage.kt
+++ b/app/src/main/java/com/nervesparks/iris/ui/components/ThinkingMessage.kt
@@ -157,7 +157,7 @@ fun ThinkingMessage(
                             fontWeight = FontWeight.Medium
                         )
                         Spacer(modifier = Modifier.height(4.dp))
-                        MarkdownTextComponent(
+                        MarkdownText(
                             markdown = if (outputContent.isNotEmpty()) outputContent else message
                         )
                     }


### PR DESCRIPTION
## Summary
- rename MarkdownTextComponent composable to MarkdownText
- update imports and call sites to the new name

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6892311026008323a2e4212db7cfe916