### PR TITLE
Add search results state and integrate with search screen

### DIFF
--- a/app/src/main/java/com/nervesparks/iris/ui/components/DownloadModal.kt
+++ b/app/src/main/java/com/nervesparks/iris/ui/components/DownloadModal.kt
@@ -169,7 +169,7 @@ fun DownloadModal(viewModel: MainViewModel, dm: DownloadManager, models: List<Do
                                     isSearching = true
                                     searchError = null
                                     try {
-                                        val response = viewModel.searchModels(searchQuery)
+                                        val response = viewModel.searchModelsAsync(searchQuery)
                                         if (response.success && response.data != null) {
                                             val detailedModels = mutableListOf<Map<String, String>>()
                                             for (model in response.data.take(3)) {


### PR DESCRIPTION
## Summary
- add `searchResults` state and `searchModels(query)` method to `MainViewModel`
- render model search results, errors, and loading state in `SearchResultScreen` via ViewModel state
- adjust `DownloadModal` to use async model search

## Testing
- `./gradlew test` *(fails: SDK location not found)*


------
https://chatgpt.com/codex/tasks/task_e_689231139be48323bfdd6094d173b72f