### PR TITLE
Add toggle for performance monitor

### DIFF
--- a/app/src/main/java/com/nervesparks/iris/MainViewModel.kt
+++ b/app/src/main/java/com/nervesparks/iris/MainViewModel.kt
@@ -120,6 +120,7 @@ class MainViewModel @Inject constructor(
     var showModal by mutableStateOf(true)
     var showDownloadInfoModal by mutableStateOf(false)
     var showModelSelection by mutableStateOf(false)
+    var showPerformanceMonitor by mutableStateOf(false)
     var selectedModelForSwitch by mutableStateOf("")
     var user_thread by mutableStateOf(0f)
     var topP by mutableStateOf(0.9f)
@@ -174,6 +175,10 @@ class MainViewModel @Inject constructor(
 
     fun onFilesAttachment() {
         lastAttachmentAction = "files"
+    }
+
+    fun togglePerformanceMonitor() {
+        showPerformanceMonitor = !showPerformanceMonitor
     }
 
     // Performance monitoring variables

--- a/app/src/main/java/com/nervesparks/iris/ui/MainChatScreen.kt
+++ b/app/src/main/java/com/nervesparks/iris/ui/MainChatScreen.kt
@@ -690,7 +690,7 @@ fun MainChatScreen (
                                 }
                                 
                                 // Performance Monitor at bottom
-                                if (viewModel.isGenerating || viewModel.tps > 0.0) {
+                                if (viewModel.showPerformanceMonitor && (viewModel.isGenerating || viewModel.tps > 0.0)) {
                                     item {
                                         PerformanceMonitor(viewModel = viewModel)
                                     }

--- a/app/src/main/java/com/nervesparks/iris/ui/components/ChatSection.kt
+++ b/app/src/main/java/com/nervesparks/iris/ui/components/ChatSection.kt
@@ -42,7 +42,9 @@ fun ChatMessageList(viewModel: MainViewModel, scrollState: LazyListState) {
         LazyColumn(state = scrollState) {
             // Add performance monitor at the top
             item {
-                PerformanceMonitor(viewModel = viewModel)
+                if (viewModel.showPerformanceMonitor) {
+                    PerformanceMonitor(viewModel = viewModel)
+                }
             }
             
             itemsIndexed(messages.drop(3)) { index, messageMap ->

--- a/app/src/main/java/com/nervesparks/iris/ui/components/PerformanceMonitor.kt
+++ b/app/src/main/java/com/nervesparks/iris/ui/components/PerformanceMonitor.kt
@@ -3,8 +3,11 @@ package com.nervesparks.iris.ui.components
 import android.content.res.Configuration
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ExpandLess
+import androidx.compose.material.icons.filled.ExpandMore
 import androidx.compose.material3.*
-import androidx.compose.runtime.Composable
+import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -43,6 +46,7 @@ fun PerformanceMonitor(viewModel: MainViewModel) {
 
 @Composable
 fun PerformanceMonitor(state: PerformanceMonitorState) {
+    var expanded by remember { mutableStateOf(true) }
     Card(
         modifier = Modifier
             .fillMaxWidth()
@@ -56,50 +60,65 @@ fun PerformanceMonitor(state: PerformanceMonitorState) {
                 .fillMaxWidth()
                 .padding(12.dp)
         ) {
-            Text(
-                text = "Performance",
-                style = MaterialTheme.typography.titleSmall,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
-                fontWeight = FontWeight.Medium
-            )
-
-            Spacer(modifier = Modifier.height(8.dp))
-
-            // Compact metrics layout
             Row(
-                modifier = Modifier.fillMaxWidth(),
-                horizontalArrangement = Arrangement.SpaceEvenly
+                verticalAlignment = Alignment.CenterVertically,
+                modifier = Modifier.fillMaxWidth()
             ) {
-                CompactMetricItem(
-                    label = "TPS",
-                    value = String.format("%.1f", state.tps),
-                    color = if (state.isGenerating) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.onSurfaceVariant
+                Text(
+                    text = "Performance",
+                    style = MaterialTheme.typography.titleSmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    fontWeight = FontWeight.Medium,
+                    modifier = Modifier.weight(1f)
                 )
-                CompactMetricItem(
-                    label = "TTFT",
-                    value = if (state.ttft > 0) "${state.ttft}ms" else "N/A",
-                    color = if (state.ttft > 0) MaterialTheme.colorScheme.tertiary else MaterialTheme.colorScheme.onSurfaceVariant
-                )
-                CompactMetricItem(
-                    label = "Memory",
-                    value = "${state.memoryUsage}MB",
-                    color = MaterialTheme.colorScheme.secondary
-                )
-                CompactMetricItem(
-                    label = "Context",
-                    value = "${state.contextLimit}/${state.maxContextLimit}",
-                    color = MaterialTheme.colorScheme.tertiary
-                )
+                IconButton(onClick = { expanded = !expanded }) {
+                    Icon(
+                        imageVector = if (expanded) Icons.Filled.ExpandLess else Icons.Filled.ExpandMore,
+                        contentDescription = if (expanded) "Collapse" else "Expand",
+                        tint = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                }
             }
 
-            // Generation progress
-            if (state.isGenerating) {
-                Spacer(modifier = Modifier.height(6.dp))
-                LinearProgressIndicator(
+            if (expanded) {
+                Spacer(modifier = Modifier.height(8.dp))
+
+                // Compact metrics layout
+                Row(
                     modifier = Modifier.fillMaxWidth(),
-                    color = MaterialTheme.colorScheme.primary,
-                    trackColor = MaterialTheme.colorScheme.primaryContainer
-                )
+                    horizontalArrangement = Arrangement.SpaceEvenly
+                ) {
+                    CompactMetricItem(
+                        label = "TPS",
+                        value = String.format("%.1f", state.tps),
+                        color = if (state.isGenerating) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                    CompactMetricItem(
+                        label = "TTFT",
+                        value = if (state.ttft > 0) "${state.ttft}ms" else "N/A",
+                        color = if (state.ttft > 0) MaterialTheme.colorScheme.tertiary else MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                    CompactMetricItem(
+                        label = "Memory",
+                        value = "${state.memoryUsage}MB",
+                        color = MaterialTheme.colorScheme.secondary
+                    )
+                    CompactMetricItem(
+                        label = "Context",
+                        value = "${state.contextLimit}/${state.maxContextLimit}",
+                        color = MaterialTheme.colorScheme.tertiary
+                    )
+                }
+
+                // Generation progress
+                if (state.isGenerating) {
+                    Spacer(modifier = Modifier.height(6.dp))
+                    LinearProgressIndicator(
+                        modifier = Modifier.fillMaxWidth(),
+                        color = MaterialTheme.colorScheme.primary,
+                        trackColor = MaterialTheme.colorScheme.primaryContainer
+                    )
+                }
             }
         }
     }

--- a/app/src/main/java/com/nervesparks/iris/ui/components/TopAppBar.kt
+++ b/app/src/main/java/com/nervesparks/iris/ui/components/TopAppBar.kt
@@ -59,6 +59,22 @@ fun ModernTopAppBar(
             }
         },
         actions = {
+            IconButton(
+                onClick = { viewModel.togglePerformanceMonitor() },
+                colors = IconButtonDefaults.iconButtonColors(
+                    containerColor = MaterialTheme.colorScheme.surfaceVariant
+                )
+            ) {
+                Icon(
+                    imageVector = Icons.Default.Speed,
+                    contentDescription = "Toggle Performance Monitor",
+                    tint = if (viewModel.showPerformanceMonitor)
+                        MaterialTheme.colorScheme.primary
+                    else
+                        MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            }
+
             // Model selection button
             if (availableModels.isNotEmpty()) {
                 Card(


### PR DESCRIPTION
## Summary
- add `showPerformanceMonitor` state to `MainViewModel` with toggle
- expose a new icon in `ModernTopAppBar` to control showing metrics
- make `PerformanceMonitor` card collapsible with expand/collapse chevron

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68923111bd3083239654f18f5e5d3784