### PR TITLE
Use unified top app bar across screens

### DIFF
--- a/app/src/main/java/com/nervesparks/iris/ui/AboutScreen.kt
+++ b/app/src/main/java/com/nervesparks/iris/ui/AboutScreen.kt
@@ -1,20 +1,12 @@
 package com.nervesparks.iris.ui
 
 import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ArrowBack
 import androidx.compose.material.icons.filled.Check
 import androidx.compose.material.icons.filled.Star
 import androidx.compose.material3.Icon
@@ -27,44 +19,55 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-
+import com.nervesparks.iris.ui.components.IrisTopAppBar
 
 @Composable
-fun AboutScreen() {
-    LazyColumn(
+fun AboutScreen(onBackClick: () -> Unit) {
+    Column(
         modifier = Modifier
             .fillMaxSize()
             .background(MaterialTheme.colorScheme.background)
-            .padding(16.dp)
     ) {
-        item {
-            SectionHeader(text = "Welcome to Iris")
-        }
-        item {
-            Text(
-                text = "Iris is an offline Android chat application powered by the llama.cpp framework. Designed to operate entirely offline, it ensures privacy and independence from external servers. Whether you're a developer exploring AI applications or a privacy-conscious user, this app provides a seamless and secure way to experience conversational AI. Please note that the app may occasionally generate inaccurate results.",
-                fontSize = 16.sp,
-                color = MaterialTheme.colorScheme.onBackground,
-                lineHeight = 24.sp
-            )
-            Spacer(modifier = Modifier.height(24.dp))
-        }
+        IrisTopAppBar(
+            title = "About",
+            navigationIcon = Icons.Default.ArrowBack,
+            onNavigationClick = onBackClick
+        )
 
-        item {
-            SectionHeader(text = "Features")
-        }
+        LazyColumn(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(16.dp)
+        ) {
+            item {
+                SectionHeader(text = "Welcome to Iris")
+            }
+            item {
+                Text(
+                    text = "Iris is an offline Android chat application powered by the llama.cpp framework. Designed to operate entirely offline, it ensures privacy and independence from external servers. Whether you're a developer exploring AI applications or a privacy-conscious user, this app provides a seamless and secure way to experience conversational AI. Please note that the app may occasionally generate inaccurate results.",
+                    fontSize = 16.sp,
+                    color = MaterialTheme.colorScheme.onBackground,
+                    lineHeight = 24.sp
+                )
+                Spacer(modifier = Modifier.height(24.dp))
+            }
 
-        items(features) { feature ->
-            FeatureItem(feature = feature)
-        }
+            item {
+                SectionHeader(text = "Features")
+            }
 
-        item {
-            Spacer(modifier = Modifier.height(24.dp))
-            SectionHeader(text = "FAQs")
-        }
+            items(features) { feature ->
+                FeatureItem(feature = feature)
+            }
 
-        items(faqs) { faq ->
-            FaqItem(question = faq.first, answer = faq.second)
+            item {
+                Spacer(modifier = Modifier.height(24.dp))
+                SectionHeader(text = "FAQs")
+            }
+
+            items(faqs) { faq ->
+                FaqItem(question = faq.first, answer = faq.second)
+            }
         }
     }
 }
@@ -155,7 +158,7 @@ private fun FaqItem(
             fontSize = 14.sp,
             color = MaterialTheme.colorScheme.onSurfaceVariant,
             lineHeight = 20.sp,
-            modifier = Modifier.padding(start = 32.dp)  // Aligned with question text
+            modifier = Modifier.padding(start = 32.dp)
         )
     }
 }
@@ -172,17 +175,8 @@ private val faqs = listOf(
     "Do I need an internet connection to use this app?" to "Yes, but only to download models to your device. After that, the app operates entirely offline. All operations are performed locally on your device.",
     "Which AI models are supported?" to "The app supports GGUF models. You can download and integrate them as needed.",
     "Is my data safe while using this app?" to "Yes, since the app works offline, no data is transmitted to external servers, ensuring complete privacy.",
-    "How do I change parameters?" to "You can adjust thread parameters to modify the text generation speed by navigating to:\n" +
-            "Settings > Change Parameters > Modify the parameters > Save changes.",
-    "How do I download models online?" to "You can download models from Hugging Face by providing the gguf model names:\n" +
-            "\n" +
-            "Go to Settings > Models.\n" +
-            "Click on Search Hugging Face Models.\n" +
-            "Enter the model name and click the search button.\n" +
-            "A list of matching models will appear. Select the model you want to download.",
-    "How do I delete a model?" to "To free up device storage, you can delete downloaded models:\n" +
-            "\n" +
-            "Go to Settings > Models.\n" +
-            "Select the model you want to delete.\n" +
-            "Click the Delete button."
+    "How do I change parameters?" to "You can adjust thread parameters to modify the text generation speed by navigating to:\nSettings > Change Parameters > Modify the parameters > Save changes.",
+    "How do I download models online?" to "You can download models from Hugging Face by providing the gguf model names:\n\nGo to Settings > Models.\nClick on Search Hugging Face Models.\nEnter the model name and click the search button.\nA list of matching models will appear. Select the model you want to download.",
+    "How do I delete a model?" to "To free up device storage, you can delete downloaded models:\n\nGo to Settings > Models.\nSelect the model you want to delete.\nClick the Delete button."
 )
+

--- a/app/src/main/java/com/nervesparks/iris/ui/BenchMarkScreen.kt
+++ b/app/src/main/java/com/nervesparks/iris/ui/BenchMarkScreen.kt
@@ -6,6 +6,8 @@ import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ArrowBack
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
@@ -16,6 +18,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import com.nervesparks.iris.MainViewModel
 import kotlinx.coroutines.launch
+import com.nervesparks.iris.ui.components.IrisTopAppBar
 
 data class BenchmarkState(
     val isRunning: Boolean = false,
@@ -25,7 +28,7 @@ data class BenchmarkState(
 )
 
 @Composable
-fun BenchMarkScreen(viewModel: MainViewModel) {
+fun BenchMarkScreen(viewModel: MainViewModel, onBackClick: () -> Unit) {
     val scope = rememberCoroutineScope()
     val scrollState = rememberScrollState()
 
@@ -37,33 +40,43 @@ fun BenchMarkScreen(viewModel: MainViewModel) {
     Column(
         modifier = Modifier
             .fillMaxSize()
-            .padding(16.dp)
-            .verticalScroll(scrollState),
-        horizontalAlignment = Alignment.CenterHorizontally
     ) {
-        // Header
-        Text(
-            "Benchmark Information",
-            style = MaterialTheme.typography.headlineMedium,
-            fontWeight = FontWeight.Bold,
-            modifier = Modifier.padding(bottom = 16.dp)
+        IrisTopAppBar(
+            title = "Benchmark",
+            navigationIcon = Icons.Default.ArrowBack,
+            onNavigationClick = onBackClick
         )
 
-        // Device Info Card
-        Card(
+        Column(
             modifier = Modifier
-                .fillMaxWidth()
-                .padding(bottom = 16.dp),
-            elevation = CardDefaults.cardElevation(defaultElevation = 4.dp)
+                .fillMaxSize()
+                .padding(16.dp)
+                .verticalScroll(scrollState),
+            horizontalAlignment = Alignment.CenterHorizontally
         ) {
-            Column(
-                modifier = Modifier.padding(16.dp)
+            // Header
+            Text(
+                "Benchmark Information",
+                style = MaterialTheme.typography.headlineMedium,
+                fontWeight = FontWeight.Bold,
+                modifier = Modifier.padding(bottom = 16.dp)
+            )
+
+            // Device Info Card
+            Card(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(bottom = 16.dp),
+                elevation = CardDefaults.cardElevation(defaultElevation = 4.dp)
             ) {
-                deviceInfo.lines().forEach { line ->
-                    Text(line, modifier = Modifier.padding(vertical = 2.dp))
+                Column(
+                    modifier = Modifier.padding(16.dp)
+                ) {
+                    deviceInfo.lines().forEach { line ->
+                        Text(line, modifier = Modifier.padding(vertical = 2.dp))
+                    }
                 }
             }
-        }
         val context = LocalContext.current
         // Benchmark Button
 

--- a/app/src/main/java/com/nervesparks/iris/ui/ChatListScreen.kt
+++ b/app/src/main/java/com/nervesparks/iris/ui/ChatListScreen.kt
@@ -8,6 +8,8 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.filled.Edit
 import androidx.compose.material.icons.filled.Search
+import androidx.compose.material.icons.filled.Menu
+import androidx.compose.material.icons.filled.Add
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
@@ -21,6 +23,7 @@ import com.nervesparks.iris.MainViewModel
 import com.nervesparks.iris.data.ChatRepository
 import com.nervesparks.iris.data.db.Chat
 import com.nervesparks.iris.ui.theme.IrisStarTheme
+import com.nervesparks.iris.ui.components.IrisTopAppBar
 import kotlinx.coroutines.launch
 import java.text.SimpleDateFormat
 import java.util.Date
@@ -30,6 +33,7 @@ fun ChatListScreen(
     viewModel: MainViewModel,
     onChatSelected: (Long) -> Unit,
     onNewChat: () -> Unit,
+    onMenuClick: () -> Unit,
 ) {
     val chats by viewModel.chats.collectAsState(initial = emptyList())
     val scope = rememberCoroutineScope()
@@ -46,6 +50,17 @@ fun ChatListScreen(
     }
 
     Column(Modifier.fillMaxSize()) {
+        IrisTopAppBar(
+            title = "Chats",
+            navigationIcon = Icons.Default.Menu,
+            onNavigationClick = onMenuClick,
+            actions = {
+                IconButton(onClick = onNewChat) {
+                    Icon(Icons.Default.Add, contentDescription = "New Chat")
+                }
+            }
+        )
+
         // Search bar
         OutlinedTextField(
             value = searchQuery,

--- a/app/src/main/java/com/nervesparks/iris/ui/ModelsScreen.kt
+++ b/app/src/main/java/com/nervesparks/iris/ui/ModelsScreen.kt
@@ -14,7 +14,11 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material.TabRowDefaults.Divider
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ArrowBack
+import androidx.compose.material.icons.filled.Search
 import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -28,10 +32,17 @@ import com.nervesparks.iris.MainViewModel
 import com.nervesparks.iris.R
 import com.nervesparks.iris.ui.components.LoadingModal
 import com.nervesparks.iris.ui.components.ModelCard
+import com.nervesparks.iris.ui.components.IrisTopAppBar
 import java.io.File
 
 @Composable
-fun ModelsScreen(extFileDir: File?, viewModel: MainViewModel, onSearchResultButtonClick: () -> Unit, dm: DownloadManager) {
+fun ModelsScreen(
+    extFileDir: File?,
+    viewModel: MainViewModel,
+    onSearchResultButtonClick: () -> Unit,
+    dm: DownloadManager,
+    onBackClick: () -> Unit
+) {
     // Observe viewModel.refresh to trigger recomposition
     val refresh = viewModel.refresh
 
@@ -40,123 +51,136 @@ fun ModelsScreen(extFileDir: File?, viewModel: MainViewModel, onSearchResultButt
         viewModel.refresh = false
     }
 
-    Box {
-        if (viewModel.showAlert) {
-            // Modal dialog to show download options
-            LoadingModal(viewModel)
-        }
+    Column(modifier = Modifier.fillMaxSize()) {
+        IrisTopAppBar(
+            title = "Models",
+            navigationIcon = Icons.Default.ArrowBack,
+            onNavigationClick = onBackClick,
+            actions = {
+                IconButton(onClick = onSearchResultButtonClick) {
+                    Icon(Icons.Default.Search, contentDescription = "Search")
+                }
+            }
+        )
 
-        val suggestedModels = viewModel.allModels.filter { it["supportsReasoning"] == "true" }.take(3)
+        Box(modifier = Modifier.fillMaxSize()) {
+            if (viewModel.showAlert) {
+                // Modal dialog to show download options
+                LoadingModal(viewModel)
+            }
 
-        LazyColumn(modifier = Modifier.padding(horizontal = 15.dp)) {
-            item {
-                Column {
-                    Row(
-                        verticalAlignment = Alignment.CenterVertically,
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .padding(horizontal = 10.dp, vertical = 5.dp)
-                            .clickable {
-                                onSearchResultButtonClick()
-                            }
-                    ) {
-                        Icon(
-                            modifier = Modifier.size(20.dp), // Icon size
-                            painter = painterResource(id = R.drawable.search_svgrepo_com__3_),
-                            contentDescription = "Parameters",
-                            tint = MaterialTheme.colorScheme.onSurface
-                        )
-                        Spacer(Modifier.width(10.dp))
-                        Text(
-                            text = "Search Hugging-Face Models",
-                            color = MaterialTheme.colorScheme.onSurface,
-                            fontSize = 18.sp,
+            val suggestedModels = viewModel.allModels.filter { it["supportsReasoning"] == "true" }.take(3)
+
+            LazyColumn(modifier = Modifier.padding(horizontal = 15.dp)) {
+                item {
+                    Column {
+                        Row(
+                            verticalAlignment = Alignment.CenterVertically,
                             modifier = Modifier
-                                .padding(vertical = 12.dp, horizontal = 7.dp)
+                                .fillMaxWidth()
+                                .padding(horizontal = 10.dp, vertical = 5.dp)
+                                .clickable {
+                                    onSearchResultButtonClick()
+                                }
+                        ) {
+                            Icon(
+                                modifier = Modifier.size(20.dp), // Icon size
+                                painter = painterResource(id = R.drawable.search_svgrepo_com__3_),
+                                contentDescription = "Parameters",
+                                tint = MaterialTheme.colorScheme.onSurface
+                            )
+                            Spacer(Modifier.width(10.dp))
+                            Text(
+                                text = "Search Hugging-Face Models",
+                                color = MaterialTheme.colorScheme.onSurface,
+                                fontSize = 18.sp,
+                                modifier = Modifier
+                                    .padding(vertical = 12.dp, horizontal = 7.dp)
+                            )
+                            Spacer(Modifier.weight(1f))
+                            Icon(
+                                modifier = Modifier.size(20.dp),
+                                painter = painterResource(id = R.drawable.right_arrow_svgrepo_com),
+                                contentDescription = null,
+                                tint = MaterialTheme.colorScheme.onSurface,
+                            )
+                        }
+                        Divider(
+                            modifier = Modifier
+                                .fillMaxWidth(),
+                            color = MaterialTheme.colorScheme.outline, // Set the color of the divider
+                            thickness = 1.dp
                         )
-                        Spacer(Modifier.weight(1f))
-                        Icon(
-                            modifier = Modifier.size(20.dp),
-                            painter = painterResource(id = R.drawable.right_arrow_svgrepo_com),
-                            contentDescription = null,
-                            tint = MaterialTheme.colorScheme.onSurface,
+                        Spacer(Modifier.height(25.dp))
+                        // Suggested Models Section
+                        Text(
+                            text = "Suggested Models",
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            modifier = Modifier.padding(5.dp),
+                            fontSize = 18.sp
                         )
                     }
+                }
+
+                // Show first three suggested models that support reasoning
+                items(suggestedModels) { model ->
+                    extFileDir?.let {
+                        model["source"]?.let { source ->
+                            ModelCard(
+                                model["name"].toString(),
+                                supportsReasoning = model["supportsReasoning"] == "true",
+                                viewModel = viewModel,
+                                dm = dm,
+                                extFilesDir = extFileDir,
+                                downloadLink = source,
+                                showDeleteButton = true
+                            )
+                        }
+                    }
+                }
+                item {
                     Divider(
                         modifier = Modifier
                             .fillMaxWidth(),
                         color = MaterialTheme.colorScheme.outline, // Set the color of the divider
                         thickness = 1.dp
                     )
-                    Spacer(Modifier.height(25.dp))
-                    // Suggested Models Section
+                }
+
+                item {
+                    // My Models Section
                     Text(
-                        text = "Suggested Models",
+                        text = "My Models",
                         color = MaterialTheme.colorScheme.onSurfaceVariant,
                         modifier = Modifier.padding(5.dp),
                         fontSize = 18.sp
                     )
                 }
-            }
 
-            // Show first three suggested models that support reasoning
-            items(suggestedModels) { model ->
-                extFileDir?.let {
-                    model["source"]?.let { source ->
-                        ModelCard(
-                            model["name"].toString(),
-                            supportsReasoning = model["supportsReasoning"] == "true",
-                            viewModel = viewModel,
-                            dm = dm,
-                            extFilesDir = extFileDir,
-                            downloadLink = source,
-                            showDeleteButton = true
-                        )
+                // Display all models not in Suggested Models
+                items(viewModel.allModels.filterNot { suggestedModels.contains(it) }) { model ->
+                    extFileDir?.let {
+                        model["source"]?.let { source ->
+                            ModelCard(
+                                model["name"].toString(),
+                                supportsReasoning = model["supportsReasoning"] == "true",
+                                viewModel = viewModel,
+                                dm = dm,
+                                extFilesDir = extFileDir,
+                                downloadLink = source,
+                                showDeleteButton = true
+                            )
+                        }
                     }
                 }
-            }
-            item {
-                Divider(
-                    modifier = Modifier
-                        .fillMaxWidth(),
-                    color = MaterialTheme.colorScheme.outline, // Set the color of the divider
-                    thickness = 1.dp
-                )
-            }
-
-            item {
-                // My Models Section
-                Text(
-                    text = "My Models",
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    modifier = Modifier.padding(5.dp),
-                    fontSize = 18.sp
-                )
-            }
-
-            // Display all models not in Suggested Models
-            items(viewModel.allModels.filterNot { suggestedModels.contains(it) }) { model ->
-                extFileDir?.let {
-                    model["source"]?.let { source ->
-                        ModelCard(
-                            model["name"].toString(),
-                            supportsReasoning = model["supportsReasoning"] == "true",
-                            viewModel = viewModel,
-                            dm = dm,
-                            extFilesDir = extFileDir,
-                            downloadLink = source,
-                            showDeleteButton = true
+                item {
+                    if (viewModel.allModels.drop(3).isEmpty()) {
+                        Text(
+                            text = "No models to show",
+                            color = MaterialTheme.colorScheme.onSurface,
+                            modifier = Modifier.padding(top = 8.dp, start = 2.dp)
                         )
                     }
-                }
-            }
-            item {
-                if (viewModel.allModels.drop(3).isEmpty()) {
-                    Text(
-                        text = "No models to show",
-                        color = MaterialTheme.colorScheme.onSurface,
-                        modifier = Modifier.padding(top = 8.dp, start = 2.dp)
-                    )
                 }
             }
         }

--- a/app/src/main/java/com/nervesparks/iris/ui/ParametersScreen.kt
+++ b/app/src/main/java/com/nervesparks/iris/ui/ParametersScreen.kt
@@ -13,6 +13,8 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ArrowBack
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Slider
 import androidx.compose.material3.SliderDefaults
@@ -31,10 +33,11 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import com.nervesparks.iris.MainViewModel
 import com.nervesparks.iris.ui.components.LoadingModal
+import com.nervesparks.iris.ui.components.IrisTopAppBar
 
 
 @Composable
-fun ParametersScreen(viewModel: MainViewModel) {
+fun ParametersScreen(viewModel: MainViewModel, onBackClick: () -> Unit) {
     val context = LocalContext.current
 
     // Main container with fillMaxSize
@@ -42,8 +45,18 @@ fun ParametersScreen(viewModel: MainViewModel) {
         modifier = Modifier
             .fillMaxSize()
             .background(MaterialTheme.colorScheme.background)
-            .padding(16.dp)
     ) {
+        IrisTopAppBar(
+            title = "Parameters",
+            navigationIcon = Icons.Default.ArrowBack,
+            onNavigationClick = onBackClick
+        )
+
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(16.dp)
+        ) {
 
 
             Text(

--- a/app/src/main/java/com/nervesparks/iris/ui/SearchResultScreen.kt
+++ b/app/src/main/java/com/nervesparks/iris/ui/SearchResultScreen.kt
@@ -18,6 +18,9 @@ import androidx.compose.foundation.layout.wrapContentSize
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ArrowBack
+import androidx.compose.material.icons.filled.Settings
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Card
@@ -54,6 +57,7 @@ import com.nervesparks.iris.data.UserPreferencesRepository
 import com.nervesparks.iris.ui.components.InfoModal
 import com.nervesparks.iris.ui.components.LoadingModal
 import com.nervesparks.iris.ui.components.ModelCard
+import com.nervesparks.iris.ui.components.IrisTopAppBar
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
@@ -65,7 +69,13 @@ import java.net.URL
 import java.net.UnknownHostException
 
 @Composable
-fun SearchResultScreen(viewModel: MainViewModel, dm: DownloadManager, extFilesDir: File) {
+fun SearchResultScreen(
+    viewModel: MainViewModel,
+    dm: DownloadManager,
+    extFilesDir: File,
+    onBackClick: () -> Unit,
+    onSettingsClick: () -> Unit
+) {
     var modelData by rememberSaveable { mutableStateOf<List<Map<String, String>>?>(null) }
     var isLoading by remember { mutableStateOf(false) }
     var errorMessage by remember { mutableStateOf<String?>(null) }
@@ -91,63 +101,63 @@ fun SearchResultScreen(viewModel: MainViewModel, dm: DownloadManager, extFilesDi
         modifier = Modifier
             .fillMaxSize()
             .background(MaterialTheme.colorScheme.background)
-            .padding(16.dp),
     ) {
-        InfoModal(
-            showDialog = viewModel.showDownloadInfoModal,
-            onDismiss = { viewModel.showDownloadInfoModal = false }
+        IrisTopAppBar(
+            title = "Search",
+            navigationIcon = Icons.Default.ArrowBack,
+            onNavigationClick = onBackClick,
+            actions = {
+                IconButton(onClick = onSettingsClick) {
+                    Icon(Icons.Default.Settings, contentDescription = "Settings")
+                }
+            }
         )
-        // Search Input and Button Row
-        Row(
-            verticalAlignment = Alignment.CenterVertically,
-            horizontalArrangement = Arrangement.SpaceBetween,
-            modifier = Modifier.fillMaxWidth()
+
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(16.dp)
         ) {
+            InfoModal(
+                showDialog = viewModel.showDownloadInfoModal,
+                onDismiss = { viewModel.showDownloadInfoModal = false }
+            )
+            // Search Input and Button Row
             Row(
                 verticalAlignment = Alignment.CenterVertically,
-                horizontalArrangement = Arrangement.Start,
-                modifier = Modifier.weight(1f)
+                horizontalArrangement = Arrangement.SpaceBetween,
+                modifier = Modifier.fillMaxWidth()
             ) {
-                Text(
-                    text = "Example: bartowski/Llama-3.2-1B-Instruct-GGUF",
-                    modifier = Modifier.padding(4.dp),
-                    color = MaterialTheme.colorScheme.onBackground,
-                    fontSize = 10.sp
-                )
-
-                IconButton(
-                    onClick = {
-                        clipboardManager.setText(AnnotatedString("bartowski/Llama-3.2-1B-Instruct-GGUF"))
-                        Toast.makeText(context, "Text copied", Toast.LENGTH_SHORT).show()
-                    },
-                    modifier = Modifier.size(16.dp)
+                Row(
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.Start,
+                    modifier = Modifier.weight(1f)
                 ) {
-                    Icon(
-                        painter = painterResource(id = R.drawable.copy1),
-                        contentDescription = "Copy text",
-                        tint = MaterialTheme.colorScheme.onBackground.copy(alpha = 0.7f),
-                        modifier = Modifier.size(14.dp)
+                    Text(
+                        text = "Example: bartowski/Llama-3.2-1B-Instruct-GGUF",
+                        modifier = Modifier.padding(4.dp),
+                        color = MaterialTheme.colorScheme.onBackground,
+                        fontSize = 10.sp
                     )
+
+                    IconButton(
+                        onClick = {
+                            clipboardManager.setText(AnnotatedString("bartowski/Llama-3.2-1B-Instruct-GGUF"))
+                            Toast.makeText(context, "Text copied", Toast.LENGTH_SHORT).show()
+                        },
+                        modifier = Modifier.size(16.dp)
+                    ) {
+                        Icon(
+                            painter = painterResource(id = R.drawable.copy1),
+                            contentDescription = "Copy text",
+                            tint = MaterialTheme.colorScheme.onBackground.copy(alpha = 0.7f),
+                            modifier = Modifier.size(14.dp)
+                        )
+                    }
                 }
             }
-            
-            // Settings button
-            IconButton(
-                onClick = {
-                    // Show a message to guide users to settings
-                    Toast.makeText(context, "Go to Settings > HuggingFace Integration to add credentials", Toast.LENGTH_LONG).show()
-                }
-            ) {
-                Icon(
-                    painter = painterResource(id = R.drawable.setting_4_svgrepo_com),
-                    contentDescription = "Settings",
-                    tint = MaterialTheme.colorScheme.onBackground.copy(alpha = 0.7f),
-                    modifier = Modifier.size(20.dp)
-                )
-            }
-        }
-        Spacer(Modifier.height(2.dp))
-        OutlinedTextField(
+            Spacer(Modifier.height(2.dp))
+            OutlinedTextField(
             value = UserGivenModel,
             onValueChange = { newValue ->
                 UserGivenModel = newValue

--- a/app/src/main/java/com/nervesparks/iris/ui/SettingsScreen.kt
+++ b/app/src/main/java/com/nervesparks/iris/ui/SettingsScreen.kt
@@ -11,6 +11,9 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ArrowBack
 import androidx.compose.material.icons.filled.Check
 import androidx.compose.material.icons.filled.Star
+import androidx.compose.material.icons.filled.Tune
+import androidx.compose.material.icons.filled.Info
+import androidx.compose.material.icons.filled.Speed
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
@@ -25,6 +28,7 @@ import com.nervesparks.iris.data.UserPreferencesRepository
 import com.nervesparks.iris.MainViewModel
 import com.nervesparks.iris.ui.components.LoadingModal
 import com.nervesparks.iris.ui.components.MemoryManager
+import com.nervesparks.iris.ui.components.IrisTopAppBar
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -34,6 +38,7 @@ fun SettingsScreen(
     onParamsScreenButtonClicked: () -> Unit,
     onAboutScreenButtonClicked: () -> Unit,
     onBenchMarkScreenButtonClicked: () -> Unit,
+    onBackClick: () -> Unit,
 ) {
     val context = LocalContext.current
     val preferencesRepository = remember { UserPreferencesRepository.getInstance(context) }
@@ -54,10 +59,25 @@ fun SettingsScreen(
         modifier = Modifier
             .fillMaxSize()
             .background(MaterialTheme.colorScheme.background)
-            .verticalScroll(rememberScrollState())
-            .padding(16.dp),
-        verticalArrangement = Arrangement.spacedBy(16.dp)
     ) {
+        IrisTopAppBar(
+            title = "Settings",
+            navigationIcon = Icons.Default.ArrowBack,
+            onNavigationClick = onBackClick,
+            actions = {
+                IconButton(onClick = onModelsScreenButtonClicked) { Icon(Icons.Default.Star, contentDescription = "Models") }
+                IconButton(onClick = onParamsScreenButtonClicked) { Icon(Icons.Default.Tune, contentDescription = "Parameters") }
+                IconButton(onClick = onBenchMarkScreenButtonClicked) { Icon(Icons.Default.Speed, contentDescription = "Benchmark") }
+                IconButton(onClick = onAboutScreenButtonClicked) { Icon(Icons.Default.Info, contentDescription = "About") }
+            }
+        )
+
+        Column(
+            modifier = Modifier
+                .verticalScroll(rememberScrollState())
+                .padding(16.dp),
+            verticalArrangement = Arrangement.spacedBy(16.dp)
+        ) {
         // HuggingFace Settings Section
         Card(
             modifier = Modifier.fillMaxWidth(),

--- a/app/src/main/java/com/nervesparks/iris/ui/components/TopAppBar.kt
+++ b/app/src/main/java/com/nervesparks/iris/ui/components/TopAppBar.kt
@@ -13,6 +13,8 @@ import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.foundation.layout.RowScope
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
@@ -21,6 +23,47 @@ import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
 import com.nervesparks.iris.MainViewModel
 import java.io.File
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun IrisTopAppBar(
+    title: String,
+    navigationIcon: ImageVector,
+    onNavigationClick: () -> Unit,
+    actions: @Composable RowScope.() -> Unit = {}
+) {
+    TopAppBar(
+        title = {
+            Text(
+                text = title,
+                style = MaterialTheme.typography.headlineMedium,
+                color = MaterialTheme.colorScheme.onSurface,
+                fontWeight = FontWeight.Bold
+            )
+        },
+        navigationIcon = {
+            IconButton(
+                onClick = onNavigationClick,
+                colors = IconButtonDefaults.iconButtonColors(
+                    containerColor = MaterialTheme.colorScheme.surfaceVariant
+                )
+            ) {
+                Icon(
+                    imageVector = navigationIcon,
+                    contentDescription = null,
+                    tint = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            }
+        },
+        actions = actions,
+        colors = TopAppBarDefaults.topAppBarColors(
+            containerColor = MaterialTheme.colorScheme.surface,
+            titleContentColor = MaterialTheme.colorScheme.onSurface,
+            navigationIconContentColor = MaterialTheme.colorScheme.onSurfaceVariant,
+            actionIconContentColor = MaterialTheme.colorScheme.onSurfaceVariant
+        )
+    )
+}
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable

--- a/app/src/main/java/com/nervesparks/iris/ui/navigation/AppNavigation.kt
+++ b/app/src/main/java/com/nervesparks/iris/ui/navigation/AppNavigation.kt
@@ -46,7 +46,8 @@ fun AppNavigation(
                 onNewChat = {
                     viewModel.clear()
                     navController.navigate(AppDestinations.CHAT)
-                }
+                },
+                onMenuClick = { navController.navigate(AppDestinations.SETTINGS) }
             )
         }
         composable("${AppDestinations.CHAT}?chatId={chatId}") { backStackEntry ->
@@ -69,7 +70,8 @@ fun AppNavigation(
                 onModelsScreenButtonClicked = { navController.navigate(AppDestinations.MODELS) },
                 onParamsScreenButtonClicked = { navController.navigate(AppDestinations.PARAMS) },
                 onAboutScreenButtonClicked = { navController.navigate(AppDestinations.ABOUT) },
-                onBenchMarkScreenButtonClicked = { navController.navigate(AppDestinations.BENCHMARK) }
+                onBenchMarkScreenButtonClicked = { navController.navigate(AppDestinations.BENCHMARK) },
+                onBackClick = { navController.popBackStack() }
             )
         }
         composable(AppDestinations.MODELS) {
@@ -77,17 +79,18 @@ fun AppNavigation(
                 extFileDir = extFilesDir,
                 viewModel = viewModel,
                 onSearchResultButtonClick = { navController.popBackStack() },
-                dm = downloadManager
+                dm = downloadManager,
+                onBackClick = { navController.popBackStack() }
             )
         }
         composable(AppDestinations.PARAMS) {
-            ParametersScreen(viewModel = viewModel)
+            ParametersScreen(viewModel = viewModel, onBackClick = { navController.popBackStack() })
         }
         composable(AppDestinations.ABOUT) {
-            AboutScreen()
+            AboutScreen(onBackClick = { navController.popBackStack() })
         }
         composable(AppDestinations.BENCHMARK) {
-            BenchMarkScreen(viewModel = viewModel)
+            BenchMarkScreen(viewModel = viewModel, onBackClick = { navController.popBackStack() })
         }
     }
 }


### PR DESCRIPTION
## Summary
- add flexible `IrisTopAppBar` component for reusable title, navigation, and actions
- apply new top bar to chat list, models, about, settings, search result, parameters, and benchmark screens
- hook up navigation callbacks in `AppNavigation` for menu/back actions

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68923102e11883238f6084fb2c70d1a8