### PR TITLE
Add document embedding and retrieval

### DIFF
--- a/app/src/main/java/com/nervesparks/iris/data/DocumentRepository.kt
+++ b/app/src/main/java/com/nervesparks/iris/data/DocumentRepository.kt
@@ -1,0 +1,36 @@
+package com.nervesparks.iris.data
+
+import com.nervesparks.iris.data.db.Document
+import com.nervesparks.iris.data.db.DocumentDao
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import javax.inject.Inject
+import kotlin.math.sqrt
+
+class DocumentRepository @Inject constructor(
+    private val documentDao: DocumentDao
+) {
+    suspend fun addDocument(text: String, embedding: List<Float>) = withContext(Dispatchers.IO) {
+        documentDao.insertDocument(Document(text = text, embedding = embedding))
+    }
+
+    suspend fun topKSimilar(embedding: List<Float>, k: Int): List<Document> = withContext(Dispatchers.IO) {
+        val docs = documentDao.getAllDocuments()
+        docs.sortedByDescending { cosineSimilarity(it.embedding, embedding) }.take(k)
+    }
+
+    private fun cosineSimilarity(a: List<Float>, b: List<Float>): Float {
+        if (a.isEmpty() || b.isEmpty()) return 0f
+        val size = minOf(a.size, b.size)
+        var dot = 0.0
+        var magA = 0.0
+        var magB = 0.0
+        for (i in 0 until size) {
+            dot += (a[i] * b[i])
+            magA += (a[i] * a[i])
+            magB += (b[i] * b[i])
+        }
+        val denom = sqrt(magA) * sqrt(magB)
+        return if (denom == 0.0) 0f else (dot / denom).toFloat()
+    }
+}

--- a/app/src/main/java/com/nervesparks/iris/data/db/AppDatabase.kt
+++ b/app/src/main/java/com/nervesparks/iris/data/db/AppDatabase.kt
@@ -2,8 +2,11 @@ package com.nervesparks.iris.data.db
 
 import androidx.room.Database
 import androidx.room.RoomDatabase
+import androidx.room.TypeConverters
 
-@Database(entities = [Chat::class, Message::class], version = 1)
+@Database(entities = [Chat::class, Message::class, Document::class], version = 2)
+@TypeConverters(Converters::class)
 abstract class AppDatabase : RoomDatabase() {
     abstract fun chatDao(): ChatDao
+    abstract fun documentDao(): DocumentDao
 }

--- a/app/src/main/java/com/nervesparks/iris/data/db/Converters.kt
+++ b/app/src/main/java/com/nervesparks/iris/data/db/Converters.kt
@@ -1,0 +1,12 @@
+package com.nervesparks.iris.data.db
+
+import androidx.room.TypeConverter
+
+class Converters {
+    @TypeConverter
+    fun fromFloatList(value: List<Float>): String = value.joinToString(",")
+
+    @TypeConverter
+    fun toFloatList(value: String): List<Float> =
+        if (value.isEmpty()) emptyList() else value.split(",").map { it.toFloat() }
+}

--- a/app/src/main/java/com/nervesparks/iris/data/db/Document.kt
+++ b/app/src/main/java/com/nervesparks/iris/data/db/Document.kt
@@ -1,0 +1,11 @@
+package com.nervesparks.iris.data.db
+
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+
+@Entity(tableName = "documents")
+data class Document(
+    @PrimaryKey(autoGenerate = true) val id: Long = 0,
+    val text: String,
+    val embedding: List<Float>
+)

--- a/app/src/main/java/com/nervesparks/iris/data/db/DocumentDao.kt
+++ b/app/src/main/java/com/nervesparks/iris/data/db/DocumentDao.kt
@@ -1,0 +1,15 @@
+package com.nervesparks.iris.data.db
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+
+@Dao
+interface DocumentDao {
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insertDocument(document: Document): Long
+
+    @Query("SELECT * FROM documents")
+    suspend fun getAllDocuments(): List<Document>
+}

--- a/app/src/main/java/com/nervesparks/iris/di/DatabaseModule.kt
+++ b/app/src/main/java/com/nervesparks/iris/di/DatabaseModule.kt
@@ -2,9 +2,9 @@ package com.nervesparks.iris.di
 
 import android.content.Context
 import androidx.room.Room
-import com.nervesparks.iris.data.ChatRepository
 import com.nervesparks.iris.data.db.AppDatabase
 import com.nervesparks.iris.data.db.ChatDao
+import com.nervesparks.iris.data.db.DocumentDao
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
@@ -29,5 +29,10 @@ object DatabaseModule {
     @Provides
     fun provideChatDao(appDatabase: AppDatabase): ChatDao {
         return appDatabase.chatDao()
+    }
+
+    @Provides
+    fun provideDocumentDao(appDatabase: AppDatabase): DocumentDao {
+        return appDatabase.documentDao()
     }
 }

--- a/app/src/main/java/com/nervesparks/iris/ui/components/DocumentManager.kt
+++ b/app/src/main/java/com/nervesparks/iris/ui/components/DocumentManager.kt
@@ -1,0 +1,40 @@
+package com.nervesparks.iris.ui.components
+
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.height
+import androidx.compose.material3.Button
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.unit.dp
+import com.nervesparks.iris.MainViewModel
+
+@Composable
+fun DocumentManager(viewModel: MainViewModel, modifier: Modifier = Modifier) {
+    val context = LocalContext.current
+    val documentText = remember { mutableStateOf<String?>(null) }
+    val launcher = rememberLauncherForActivityResult(ActivityResultContracts.GetContent()) { uri ->
+        uri?.let {
+            val text = context.contentResolver.openInputStream(it)?.bufferedReader().use { reader -> reader?.readText() }
+            documentText.value = text
+        }
+    }
+
+    Column(modifier = modifier) {
+        Button(onClick = { launcher.launch("text/*") }) {
+            Text("Import Document")
+        }
+        documentText.value?.let { text ->
+            Spacer(modifier = Modifier.height(8.dp))
+            Button(onClick = { viewModel.indexDocument(text) }) {
+                Text("Embed Document")
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add a Room entity and repository for storing documents and their embeddings
- expose an embedding method in MainViewModel and use it to fetch similar documents before sending
- provide a DocumentManager UI to import and embed files

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6892812a8fb08323917d7db14f9e388e