### PR TITLE
feat: add web search intent

### DIFF
--- a/app/src/main/java/com/nervesparks/iris/MainViewModel.kt
+++ b/app/src/main/java/com/nervesparks/iris/MainViewModel.kt
@@ -1,6 +1,8 @@
 package com.nervesparks.iris
 
+import android.app.SearchManager
 import android.content.Context
+import android.content.Intent
 import android.llama.cpp.LLamaAndroid
 import android.net.Uri
 import androidx.lifecycle.viewModelScope
@@ -146,6 +148,18 @@ class MainViewModel @Inject constructor(
 
     var eot_str = ""
 
+    fun performWebSearch(query: String) {
+        val context = getApplication<Application>()
+        val intent = Intent(Intent.ACTION_WEB_SEARCH).apply {
+            putExtra(SearchManager.QUERY, query)
+            addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+        }
+        context.startActivity(intent)
+
+        // TODO: Optionally capture results via WebView and
+        // forward content to the summarization pipeline.
+    }
+
     // Quick action and attachment handlers
     var lastQuickAction by mutableStateOf<String?>(null)
         private set
@@ -154,14 +168,17 @@ class MainViewModel @Inject constructor(
 
     fun onLatestNews() {
         lastQuickAction = "latest_news"
+        performWebSearch("latest news")
     }
 
     fun onCreateImages() {
         lastQuickAction = "create_images"
+        performWebSearch("create images")
     }
 
     fun onCartoonStyle() {
         lastQuickAction = "cartoon_style"
+        performWebSearch("cartoon style art")
     }
 
     fun onCameraAttachment() {


### PR DESCRIPTION
## Summary
- add performWebSearch helper in MainViewModel
- tie quick actions to web search queries

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6892812b7ca48323ba20b421f859b971