### PR TITLE
Add LocalActionHandler for quick and attachment intents

### DIFF
--- a/app/src/main/java/com/nervesparks/iris/MainViewModel.kt
+++ b/app/src/main/java/com/nervesparks/iris/MainViewModel.kt
@@ -176,6 +176,14 @@ class MainViewModel @Inject constructor(
         lastAttachmentAction = "files"
     }
 
+    fun clearLastQuickAction() {
+        lastQuickAction = null
+    }
+
+    fun clearLastAttachmentAction() {
+        lastAttachmentAction = null
+    }
+
     // Performance monitoring variables
     var tps by mutableStateOf(0.0) // Tokens per second
     var ttft by mutableStateOf(0L) // Time to first token (milliseconds)

--- a/app/src/main/java/com/nervesparks/iris/ui/LocalActionHandler.kt
+++ b/app/src/main/java/com/nervesparks/iris/ui/LocalActionHandler.kt
@@ -1,0 +1,55 @@
+package com.nervesparks.iris.ui
+
+import android.content.Context
+import android.content.Intent
+import android.net.Uri
+import android.provider.MediaStore
+import com.nervesparks.iris.MainViewModel
+
+class LocalActionHandler(private val context: Context) {
+    fun handleQuickAction(action: String?, viewModel: MainViewModel) {
+        when (action) {
+            "create_images" -> {
+                val intent = Intent(Intent.ACTION_PICK, MediaStore.Images.Media.EXTERNAL_CONTENT_URI)
+                intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+                context.startActivity(intent)
+            }
+            "latest_news" -> {
+                val intent = Intent(Intent.ACTION_VIEW, Uri.parse("https://news.google.com"))
+                intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+                context.startActivity(intent)
+            }
+            "cartoon_style" -> {
+                val intent = Intent(Intent.ACTION_VIEW, Uri.parse("https://www.google.com/search?q=cartoon+style"))
+                intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+                context.startActivity(intent)
+            }
+        }
+        viewModel.clearLastQuickAction()
+    }
+
+    fun handleAttachmentAction(action: String?, viewModel: MainViewModel) {
+        when (action) {
+            "camera" -> {
+                val intent = Intent(MediaStore.ACTION_IMAGE_CAPTURE)
+                intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+                context.startActivity(intent)
+            }
+            "photos" -> {
+                val intent = Intent(Intent.ACTION_PICK, MediaStore.Images.Media.EXTERNAL_CONTENT_URI)
+                intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+                context.startActivity(intent)
+            }
+            "files" -> {
+                val intent = Intent(Intent.ACTION_GET_CONTENT).apply {
+                    type = "*/*"
+                    addCategory(Intent.CATEGORY_OPENABLE)
+                    addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+                }
+                context.startActivity(Intent.createChooser(intent, "Select File"))
+            }
+        }
+        viewModel.clearLastAttachmentAction()
+    }
+}
+

--- a/app/src/main/java/com/nervesparks/iris/ui/screens/MainChatScreen2.kt
+++ b/app/src/main/java/com/nervesparks/iris/ui/screens/MainChatScreen2.kt
@@ -15,6 +15,7 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.rememberDrawerState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -25,6 +26,7 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
 import androidx.navigation.NavController
 import com.nervesparks.iris.MainViewModel
+import com.nervesparks.iris.ui.LocalActionHandler
 import com.nervesparks.iris.ui.components.ChatMessageList
 import com.nervesparks.iris.ui.components.ModernChatInput
 import com.nervesparks.iris.ui.components.ModernTopAppBar
@@ -73,8 +75,21 @@ fun MainChatScreen2(
 
     val context = LocalContext.current
     val extFilesDir = context.getExternalFilesDir(null)
+    val actionHandler = remember { LocalActionHandler(context) }
 
     var showModelDropdown by remember { mutableStateOf(false) }
+
+    LaunchedEffect(viewModel.lastQuickAction) {
+        viewModel.lastQuickAction?.let {
+            actionHandler.handleQuickAction(it, viewModel)
+        }
+    }
+
+    LaunchedEffect(viewModel.lastAttachmentAction) {
+        viewModel.lastAttachmentAction?.let {
+            actionHandler.handleAttachmentAction(it, viewModel)
+        }
+    }
 
     ModalNavigationDrawer(
         drawerState = drawerState,
@@ -131,8 +146,11 @@ fun MainChatScreen2(
                         value = viewModel.message,
                         onValueChange = { viewModel.updateMessage(it) },
                         onSend = { viewModel.send() },
-                        onAttachmentClick = { /*TODO*/ },
-                        onVoiceClick = { { /*TODO*/ } }
+                        onAttachmentClick = {},
+                        onVoiceClick = {},
+                        onCameraClick = { viewModel.onCameraAttachment() },
+                        onPhotosClick = { viewModel.onPhotosAttachment() },
+                        onFilesClick = { viewModel.onFilesAttachment() }
                     )
                 }
             }


### PR DESCRIPTION
## Summary
- interpret lastQuickAction and lastAttachmentAction via new LocalActionHandler
- trigger context intents for camera, photo picker, file picker and quick actions
- hook handler into MainChatScreen2 with state effects and expose attachment callbacks

## Testing
- `./gradlew test` *(fails: SDK location not found and Android SDK licenses not accepted)*

------
https://chatgpt.com/codex/tasks/task_e_6892812b48248323a841c49642df7ade