### PR TITLE
Add OCR processing and document summarization

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -115,6 +115,10 @@ dependencies {
 
     // Timber
     implementation("com.jakewharton.timber:timber:5.0.1")
+
+    // ML Kit OCR
+    implementation("com.google.mlkit:text-recognition:16.0.0")
+    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-play-services:1.7.3")
 }
 
 kapt {

--- a/app/src/main/java/com/nervesparks/iris/MainViewModel.kt
+++ b/app/src/main/java/com/nervesparks/iris/MainViewModel.kt
@@ -176,6 +176,23 @@ class MainViewModel @Inject constructor(
         lastAttachmentAction = "files"
     }
 
+    fun summarizeDocument(text: String) {
+        addMessage("user", "Summarize the attached document.")
+        val prompt = "Summarize: $text"
+        viewModelScope.launch {
+            startGeneration()
+            try {
+                llamaAndroid.send(prompt)
+                    .catch { addMessage("error", it.message ?: "") }
+                    .collect { response ->
+                        addMessage("assistant", response)
+                    }
+            } finally {
+                endGeneration()
+            }
+        }
+    }
+
     // Performance monitoring variables
     var tps by mutableStateOf(0.0) // Tokens per second
     var ttft by mutableStateOf(0L) // Time to first token (milliseconds)

--- a/app/src/main/java/com/nervesparks/iris/ocr/OcrProcessor.kt
+++ b/app/src/main/java/com/nervesparks/iris/ocr/OcrProcessor.kt
@@ -1,0 +1,52 @@
+package com.nervesparks.iris.ocr
+
+import android.content.Context
+import android.graphics.Bitmap
+import android.graphics.pdf.PdfRenderer
+import android.net.Uri
+import android.os.ParcelFileDescriptor
+import com.google.mlkit.vision.common.InputImage
+import com.google.mlkit.vision.text.TextRecognition
+import com.google.mlkit.vision.text.latin.TextRecognizerOptions
+import kotlinx.coroutines.tasks.await
+
+/**
+ * Utility for performing OCR using ML Kit's on-device text recognition.
+ */
+object OcrProcessor {
+    private val recognizer = TextRecognition.getClient(TextRecognizerOptions.Builder().build())
+
+    suspend fun processImage(bitmap: Bitmap): String {
+        val image = InputImage.fromBitmap(bitmap, 0)
+        val result = recognizer.process(image).await()
+        return result.text
+    }
+
+    suspend fun process(context: Context, uri: Uri): String {
+        val type = context.contentResolver.getType(uri)
+        return if (type == "application/pdf") {
+            processPdf(context, uri)
+        } else {
+            val image = InputImage.fromFilePath(context, uri)
+            val result = recognizer.process(image).await()
+            result.text
+        }
+    }
+
+    private suspend fun processPdf(context: Context, uri: Uri): String {
+        val sb = StringBuilder()
+        context.contentResolver.openFileDescriptor(uri, "r")?.use { pfd ->
+            val renderer = PdfRenderer(pfd)
+            for (i in 0 until renderer.pageCount) {
+                renderer.openPage(i).use { page ->
+                    val bitmap = Bitmap.createBitmap(page.width, page.height, Bitmap.Config.ARGB_8888)
+                    page.render(bitmap, null, null, PdfRenderer.Page.RENDER_MODE_FOR_DISPLAY)
+                    val pageText = processImage(bitmap)
+                    sb.append(pageText).append('\n')
+                }
+            }
+        }
+        return sb.toString()
+    }
+}
+


### PR DESCRIPTION
## Summary
- handle camera, photo library, and PDF file attachments in `MainChatScreen2`
- add ML Kit-based `OcrProcessor` for text recognition from images or PDFs
- implement `summarizeDocument` in `MainViewModel` to send OCR text to the LLM and display summary
- include ML Kit and coroutines dependencies

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6892812ab158832385e925839373d8cb