### PR TITLE
Specify backend identifier

### DIFF
--- a/llama/src/main/cpp/llama-android.cpp
+++ b/llama/src/main/cpp/llama-android.cpp
@@ -343,7 +343,20 @@ Java_android_llama_cpp_LLamaAndroid_bench_1model(
     const auto model_size     = double(llama_model_size(model)) / 1024.0 / 1024.0 / 1024.0;
     const auto model_n_params = double(llama_model_n_params(model)) / 1e9;
 
-    const auto backend    = "(Android)"; // TODO: What should this be?
+    // Determine backend based on build flags so benchmarks report the
+    // actual runtime used. This mirrors the backends supported by
+    // ggml/llama.cpp.
+#if defined(GGML_USE_CUDA)
+    const auto backend    = "CUDA";
+#elif defined(GGML_USE_VULKAN)
+    const auto backend    = "Vulkan";
+#elif defined(GGML_USE_METAL) || defined(GGML_USE_MPS)
+    const auto backend    = "Metal";
+#elif defined(GGML_USE_CLBLAST) || defined(GGML_USE_OPENCL)
+    const auto backend    = "OpenCL";
+#else
+    const auto backend    = "CPU";
+#endif
 
     std::stringstream result;
     result << std::setprecision(2);


### PR DESCRIPTION
## Summary
- select backend string (CPU, CUDA, Vulkan, Metal, OpenCL) based on compile-time flags for benchmark output

## Testing
- `./gradlew :llama:assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68936c7558148323ac7b32deef35fc57