### PR TITLE
Add unit, integration, and UI tests

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -90,10 +90,12 @@ dependencies {
         exclude(group = "com.google.guava", module = "listenablefuture")
     }
     testImplementation("org.robolectric:robolectric:4.10.3")
+    testImplementation("com.squareup.okhttp3:mockwebserver:4.12.0")
     androidTestImplementation("androidx.test.ext:junit:1.1.5")
     androidTestImplementation("androidx.test.espresso:espresso-core:3.5.1")
     androidTestImplementation(platform("androidx.compose:compose-bom:2024.02.00"))
     androidTestImplementation("androidx.compose.ui:ui-test-junit4")
+    androidTestImplementation("io.mockk:mockk-android:1.13.8")
     debugImplementation("androidx.compose.ui:ui-tooling")
     debugImplementation("androidx.compose.ui:ui-test-manifest")
     implementation("androidx.core:core-splashscreen:1.0.1")

--- a/app/src/androidTest/java/com/nervesparks/iris/ui/ChatListScreenTest.kt
+++ b/app/src/androidTest/java/com/nervesparks/iris/ui/ChatListScreenTest.kt
@@ -1,0 +1,47 @@
+package com.nervesparks.iris.ui
+
+import androidx.activity.ComponentActivity
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.nervesparks.iris.MainViewModel
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.flow.MutableStateFlow
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class ChatListScreenTest {
+
+    @get:Rule
+    val composeRule = createAndroidComposeRule<ComponentActivity>()
+
+    @Test
+    fun newChatButtonInvokesCallback() {
+        val viewModel = mockk<MainViewModel>(relaxed = true)
+        every { viewModel.chats } returns MutableStateFlow(emptyList())
+        var called = false
+        composeRule.setContent {
+            ChatListScreen(viewModel = viewModel, onChatSelected = {}, onNewChat = { called = true })
+        }
+        composeRule.onNodeWithContentDescription("New Chat").performClick()
+        assertTrue(called)
+    }
+
+    @Test
+    fun showsEmptyStateWhenNoChats() {
+        val viewModel = mockk<MainViewModel>(relaxed = true)
+        every { viewModel.chats } returns MutableStateFlow(emptyList())
+        composeRule.setContent {
+            ChatListScreen(viewModel = viewModel, onChatSelected = {}, onNewChat = {})
+        }
+        composeRule.onNodeWithText("No chats yet.").assertIsDisplayed()
+    }
+}
+

--- a/app/src/test/java/com/nervesparks/iris/data/DocumentRepositoryTest.kt
+++ b/app/src/test/java/com/nervesparks/iris/data/DocumentRepositoryTest.kt
@@ -1,0 +1,50 @@
+package com.nervesparks.iris.data
+
+import com.nervesparks.iris.data.db.Document
+import com.nervesparks.iris.data.db.DocumentDao
+import com.nervesparks.iris.data.exceptions.ValidationException
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertThrows
+import org.junit.Test
+
+class DocumentRepositoryTest {
+
+    private class FakeDocumentDao : DocumentDao {
+        val docs = mutableListOf<Document>()
+        override suspend fun insertDocument(document: Document): Long {
+            val id = (docs.size + 1).toLong()
+            docs.add(document.copy(id = id))
+            return id
+        }
+        override suspend fun getAllDocuments(): List<Document> = docs.toList()
+    }
+
+    private val dao = FakeDocumentDao()
+    private val repository = DocumentRepository(dao)
+
+    @Test
+    fun addDocumentRejectsBlankText() {
+        assertThrows(ValidationException::class.java) {
+            runBlocking { repository.addDocument("", listOf(0.1f)) }
+        }
+    }
+
+    @Test
+    fun addDocumentStoresValidDocument() = runBlocking {
+        repository.addDocument("hello", listOf(0.1f, 0.2f))
+        assertEquals(1, dao.docs.size)
+    }
+
+    @Test
+    fun topKSimilarReturnsMostSimilar() = runBlocking {
+        dao.docs.clear()
+        repository.addDocument("A", listOf(1f, 0f))
+        repository.addDocument("B", listOf(0f, 1f))
+        repository.addDocument("C", listOf(1f, 1f))
+
+        val result = repository.topKSimilar(listOf(1f, 0f), 2)
+        assertEquals(listOf("A", "C"), result.map { it.text })
+    }
+}
+

--- a/app/src/test/java/com/nervesparks/iris/data/HuggingFaceApiServiceTest.kt
+++ b/app/src/test/java/com/nervesparks/iris/data/HuggingFaceApiServiceTest.kt
@@ -1,0 +1,52 @@
+package com.nervesparks.iris.data
+
+import com.squareup.moshi.Moshi
+import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
+import kotlinx.coroutines.runBlocking
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import retrofit2.Retrofit
+import retrofit2.converter.moshi.MoshiConverterFactory
+
+class HuggingFaceApiServiceTest {
+
+    private lateinit var server: MockWebServer
+    private lateinit var api: HuggingFaceApiService
+
+    @Before
+    fun setup() {
+        server = MockWebServer()
+        server.start()
+        val moshi = Moshi.Builder().add(KotlinJsonAdapterFactory()).build()
+        api = Retrofit.Builder()
+            .baseUrl(server.url("/"))
+            .addConverterFactory(MoshiConverterFactory.create(moshi))
+            .build()
+            .create(HuggingFaceApiService::class.java)
+    }
+
+    @After
+    fun tearDown() {
+        server.shutdown()
+    }
+
+    @Test
+    fun searchModelsSendsAuthHeader() {
+        val body = """[{"id":"model1","modelId":"Model 1","downloads":10,"likes":5,"tags":[]}]"""
+        server.enqueue(MockResponse().setBody(body).setResponseCode(200))
+
+        runBlocking {
+            val result = api.searchModels("test", token = "Bearer abc")
+            val request = server.takeRequest()
+            assertEquals("/models?search=test", request.path)
+            assertEquals("Bearer abc", request.getHeader("Authorization"))
+            assertEquals(1, result.size)
+            assertEquals("model1", result[0].id)
+        }
+    }
+}
+

--- a/app/src/test/java/com/nervesparks/iris/data/repository/impl/ChatRepositoryImplTest.kt
+++ b/app/src/test/java/com/nervesparks/iris/data/repository/impl/ChatRepositoryImplTest.kt
@@ -1,0 +1,60 @@
+package com.nervesparks.iris.data.repository.impl
+
+import android.content.Context
+import androidx.room.Room
+import androidx.test.core.app.ApplicationProvider
+import com.nervesparks.iris.data.db.AppDatabase
+import com.nervesparks.iris.data.exceptions.ValidationException
+import kotlinx.coroutines.runBlocking
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertThrows
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class ChatRepositoryImplTest {
+
+    private lateinit var db: AppDatabase
+    private lateinit var repository: ChatRepositoryImpl
+
+    @Before
+    fun setup() {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        db = Room.inMemoryDatabaseBuilder(context, AppDatabase::class.java)
+            .allowMainThreadQueries()
+            .build()
+        repository = ChatRepositoryImpl(db.chatDao())
+    }
+
+    @After
+    fun tearDown() {
+        db.close()
+    }
+
+    @Test
+    fun createChatAndRetrieve() = runBlocking {
+        val id = repository.createChat("My Chat")
+        val chat = repository.getChat(id)
+        assertEquals("My Chat", chat?.title)
+    }
+
+    @Test
+    fun addMessagePersists() = runBlocking {
+        val chatId = repository.createChat("Chat")
+        repository.addMessage(chatId, "user", "hello", 0)
+        val messages = repository.getMessages(chatId)
+        assertEquals(1, messages.size)
+        assertEquals("hello", messages.first().content)
+    }
+
+    @Test
+    fun updateChatTitleWithInvalidIdThrows() {
+        assertThrows(ValidationException::class.java) {
+            runBlocking { repository.updateChatTitle(0, "New") }
+        }
+    }
+}
+


### PR DESCRIPTION
## Summary
- add unit tests for DocumentRepository validation and similarity ranking
- add integration tests for chat repository database operations and HuggingFace API calls
- add Compose UI tests for chat list screen
- include dependencies for MockWebServer and MockK

## Testing
- `./gradlew test` *(fails: SDK location not found)*
- `./gradlew connectedAndroidTest` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68936c70d5dc8323b223f455e492804d