### PR TITLE
Add basic template management UI

### DIFF
--- a/app/src/main/java/com/nervesparks/iris/MainViewModel.kt
+++ b/app/src/main/java/com/nervesparks/iris/MainViewModel.kt
@@ -14,6 +14,7 @@ import androidx.compose.runtime.State
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.setValue
 import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.viewModelScope
@@ -274,6 +275,25 @@ class MainViewModel @Inject constructor(
 
     fun updateTemplate(template: String) {
         this.template = template
+    }
+
+    // User-defined prompt templates
+    var templates = mutableStateListOf<Template>()
+        private set
+
+    fun addTemplate(template: Template) {
+        templates.add(template)
+    }
+
+    fun editTemplate(updated: Template) {
+        val index = templates.indexOfFirst { it.id == updated.id }
+        if (index != -1) {
+            templates[index] = updated
+        }
+    }
+
+    fun deleteTemplate(template: Template) {
+        templates.removeAll { it.id == template.id }
     }
 
     fun clearLastQuickAction() {
@@ -1342,6 +1362,12 @@ data class ModelFile(
     val filename: String,
     val size: Long?,
     val quantType: String?
+)
+
+data class Template(
+    val id: Long = System.currentTimeMillis(),
+    val name: String,
+    val content: String
 )
 
 fun sentThreadsValue(){

--- a/app/src/main/java/com/nervesparks/iris/ui/screens/TemplatesScreen.kt
+++ b/app/src/main/java/com/nervesparks/iris/ui/screens/TemplatesScreen.kt
@@ -1,22 +1,103 @@
 package com.nervesparks.iris.ui.screens
 
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.padding
-import androidx.compose.material3.Button
-import androidx.compose.material3.Text
-import androidx.compose.runtime.Composable
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material.icons.filled.Edit
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import com.nervesparks.iris.MainViewModel
+import com.nervesparks.iris.Template
 
 @Composable
 fun TemplatesScreen(
     viewModel: MainViewModel
 ) {
+    val templates = viewModel.templates
+    var showDialog by remember { mutableStateOf(false) }
+    var editingTemplate by remember { mutableStateOf<Template?>(null) }
+
     Column(modifier = Modifier.padding(16.dp)) {
         Text("Templates")
-        Button(onClick = { /* TODO: Add new template */ }) {
+        Button(onClick = {
+            editingTemplate = null
+            showDialog = true
+        }) {
             Text("Add Template")
         }
+
+        LazyColumn(modifier = Modifier.fillMaxWidth()) {
+            items(templates) { template ->
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(vertical = 8.dp),
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    Text(
+                        template.name,
+                        modifier = Modifier.weight(1f)
+                    )
+                    IconButton(onClick = {
+                        editingTemplate = template
+                        showDialog = true
+                    }) {
+                        Icon(Icons.Default.Edit, contentDescription = "Edit")
+                    }
+                    IconButton(onClick = { viewModel.deleteTemplate(template) }) {
+                        Icon(Icons.Default.Delete, contentDescription = "Delete")
+                    }
+                }
+            }
+        }
+    }
+
+    if (showDialog) {
+        var name by remember(editingTemplate) { mutableStateOf(editingTemplate?.name ?: "") }
+        var content by remember(editingTemplate) { mutableStateOf(editingTemplate?.content ?: "") }
+
+        AlertDialog(
+            onDismissRequest = { showDialog = false },
+            title = { Text(if (editingTemplate == null) "New Template" else "Edit Template") },
+            text = {
+                Column {
+                    TextField(
+                        value = name,
+                        onValueChange = { name = it },
+                        label = { Text("Name") },
+                        modifier = Modifier.fillMaxWidth()
+                    )
+                    Spacer(modifier = Modifier.height(8.dp))
+                    TextField(
+                        value = content,
+                        onValueChange = { content = it },
+                        label = { Text("Content") },
+                        modifier = Modifier.fillMaxWidth()
+                    )
+                }
+            },
+            confirmButton = {
+                TextButton(onClick = {
+                    if (editingTemplate == null) {
+                        viewModel.addTemplate(Template(name = name, content = content))
+                    } else {
+                        viewModel.editTemplate(editingTemplate!!.copy(name = name, content = content))
+                    }
+                    showDialog = false
+                }) {
+                    Text("Save")
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = { showDialog = false }) {
+                    Text("Cancel")
+                }
+            }
+        )
     }
 }


### PR DESCRIPTION
## Summary
- add in-memory template list to MainViewModel
- implement Templates screen with dialog for adding/editing templates and list with edit/delete actions

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68936c7b01288323aca7566ab4829d84