### PR TITLE
Implement background model update checks

### DIFF
--- a/app/src/main/java/com/nervesparks/iris/MainActivity.kt
+++ b/app/src/main/java/com/nervesparks/iris/MainActivity.kt
@@ -64,15 +64,12 @@ import android.app.Application
 import androidx.compose.foundation.border
 import androidx.activity.viewModels
 import androidx.fragment.app.FragmentActivity
-import androidx.work.PeriodicWorkRequestBuilder
-import androidx.work.WorkManager
 import com.nervesparks.iris.data.UserPreferencesRepository
 import com.nervesparks.iris.security.BiometricAuthenticator
 import com.nervesparks.iris.ui.theme.IrisStarTheme
 import com.nervesparks.iris.ui.navigation.AppNavigation
 import com.nervesparks.iris.workers.ModelUpdateWorker
 import dagger.hilt.android.AndroidEntryPoint
-import java.util.concurrent.TimeUnit
 import javax.inject.Inject
 
 @AndroidEntryPoint
@@ -129,8 +126,7 @@ class MainActivity : FragmentActivity() {
             viewModel.loadExistingModels(extFilesDir)
         }
 
-        val workRequest = PeriodicWorkRequestBuilder<ModelUpdateWorker>(1, TimeUnit.DAYS).build()
-        WorkManager.getInstance(this).enqueue(workRequest)
+        ModelUpdateWorker.schedule(this)
 
         if (preferencesRepository.getSecurityBiometricEnabled()) {
             val biometricAuthenticator = BiometricAuthenticator(this)

--- a/app/src/main/java/com/nervesparks/iris/workers/ModelUpdateWorker.kt
+++ b/app/src/main/java/com/nervesparks/iris/workers/ModelUpdateWorker.kt
@@ -1,16 +1,134 @@
 package com.nervesparks.iris.workers
 
 import android.content.Context
+import android.util.Log
+import androidx.work.Constraints
 import androidx.work.CoroutineWorker
+import androidx.work.ExistingPeriodicWorkPolicy
+import androidx.work.NetworkType
+import androidx.work.PeriodicWorkRequestBuilder
+import androidx.work.WorkManager
 import androidx.work.WorkerParameters
+import com.nervesparks.iris.data.UserPreferencesRepository
+import com.squareup.moshi.JsonClass
+import com.squareup.moshi.Moshi
+import com.squareup.moshi.Types
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import java.io.File
+import java.io.FileOutputStream
+import java.security.MessageDigest
+import java.util.concurrent.TimeUnit
 
+/**
+ * Background worker that checks for model updates and downloads new versions
+ * when available.
+ */
 class ModelUpdateWorker(
     appContext: Context,
     workerParams: WorkerParameters
 ) : CoroutineWorker(appContext, workerParams) {
 
-    override suspend fun doWork(): Result {
-        // TODO: Implement model update check
-        return Result.success()
+    private val client = OkHttpClient()
+    private val moshi = Moshi.Builder().build()
+    private val prefs = UserPreferencesRepository.getInstance(appContext)
+
+    override suspend fun doWork(): Result = withContext(Dispatchers.IO) {
+        val modelsDir = applicationContext.getExternalFilesDir(null)
+            ?: return@withContext Result.failure()
+
+        val cachedJson = prefs.getCachedModels()
+        if (cachedJson.isBlank()) return@withContext Result.success()
+
+        val listType = Types.newParameterizedType(List::class.java, CachedModel::class.java)
+        val adapter = moshi.adapter<List<CachedModel>>(listType)
+        val models = adapter.fromJson(cachedJson) ?: emptyList()
+
+        var allSuccess = true
+
+        for (model in models) {
+            val dest = File(modelsDir, model.destination)
+            if (!dest.exists() || model.source == "local") continue
+
+            try {
+                val headReq = Request.Builder().url(model.source).head().build()
+                client.newCall(headReq).execute().use { resp ->
+                    if (!resp.isSuccessful) return@use
+                    val remoteSize = resp.header("Content-Length")?.toLong() ?: -1L
+                    val remoteHash = resp.header("ETag")?.replace("\"", "")
+                    val localHash = sha256(dest)
+                    val needsUpdate =
+                        (remoteSize > 0 && remoteSize != dest.length()) ||
+                        (remoteHash != null && remoteHash != localHash)
+                    if (needsUpdate) {
+                        downloadFile(model.source, dest)
+                    }
+                }
+            } catch (e: Exception) {
+                Log.e("ModelUpdateWorker", "Error updating ${model.name}", e)
+                allSuccess = false
+            }
+        }
+
+        if (allSuccess) Result.success() else Result.failure()
+    }
+
+    private suspend fun downloadFile(url: String, dest: File) {
+        withContext(Dispatchers.IO) {
+            val request = Request.Builder().url(url).build()
+            client.newCall(request).execute().use { response ->
+                if (!response.isSuccessful) throw RuntimeException("HTTP ${response.code}")
+                response.body?.byteStream()?.use { input ->
+                    FileOutputStream(dest).use { output ->
+                        input.copyTo(output)
+                    }
+                }
+            }
+        }
+    }
+
+    private fun sha256(file: File): String {
+        val buffer = ByteArray(DEFAULT_BUFFER_SIZE)
+        val digest = MessageDigest.getInstance("SHA-256")
+        file.inputStream().use { input ->
+            var read = input.read(buffer)
+            while (read > 0) {
+                digest.update(buffer, 0, read)
+                read = input.read(buffer)
+            }
+        }
+        return digest.digest().joinToString(separator = "") { b -> "%02x".format(b) }
+    }
+
+    @JsonClass(generateAdapter = true)
+    data class CachedModel(
+        val name: String,
+        val source: String,
+        val destination: String,
+        val supportsReasoning: Boolean = false
+    )
+
+    companion object {
+        private const val WORK_NAME = "model_update"
+
+        /** Schedule periodic model update checks. */
+        fun schedule(context: Context) {
+            val request = PeriodicWorkRequestBuilder<ModelUpdateWorker>(1, TimeUnit.DAYS)
+                .setConstraints(
+                    Constraints.Builder()
+                        .setRequiredNetworkType(NetworkType.CONNECTED)
+                        .build()
+                )
+                .build()
+
+            WorkManager.getInstance(context).enqueueUniquePeriodicWork(
+                WORK_NAME,
+                ExistingPeriodicWorkPolicy.KEEP,
+                request
+            )
+        }
     }
 }
+


### PR DESCRIPTION
## Summary
- implement ModelUpdateWorker to fetch remote model metadata, verify size/hash and download updates
- expose schedule() helper to run worker daily with network constraint
- call new scheduling helper from MainActivity

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68936c76d8a48323b5c7a74fd1fc8cb5