### PR TITLE
Define backup include and exclude rules

### DIFF
--- a/app/src/main/res/xml/data_extraction_rules.xml
+++ b/app/src/main/res/xml/data_extraction_rules.xml
@@ -5,10 +5,10 @@
 -->
 <data-extraction-rules>
     <cloud-backup>
-        <!-- TODO: Use <include> and <exclude> to control what is backed up.
-        <include .../>
-        <exclude .../>
-        -->
+        <include domain="sharedpref" path="user_preferences.xml"/>
+        <exclude domain="sharedpref" path="device.xml"/>
+        <include domain="database" path="iris_chats.db"/>
+        <exclude domain="database" path="debug.db"/>
     </cloud-backup>
     <!--
     <device-transfer>


### PR DESCRIPTION
## Summary
- Configure cloud backup rules to include user preferences and main database
- Exclude device-specific preferences and debug database from backup

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68936c75dd448323a603907704aa8b82