### PR TITLE
Fix reasoning formatting to preserve newlines

### DIFF
--- a/app/src/main/java/com/nervesparks/iris/ui/components/ThinkingMessage.kt
+++ b/app/src/main/java/com/nervesparks/iris/ui/components/ThinkingMessage.kt
@@ -174,7 +174,9 @@ fun ThinkingMessage(
                         )
                         Spacer(modifier = Modifier.height(ComponentStyles.smallPadding))
                         MarkdownTextComponent(
-                            markdown = if (outputContent.isNotEmpty()) outputContent else message
+                            markdown = formatThinkingContent(
+                                if (outputContent.isNotEmpty()) outputContent else message
+                            )
                         )
                     }
                 }
@@ -223,6 +225,6 @@ private fun formatThinkingContent(content: String): String {
         .replace(Regex("([a-z])([A-Z])"), "$1 $2") // Add spaces between camelCase
         .replace(Regex("([a-z])([0-9])"), "$1 $2") // Add spaces between letters and numbers
         .replace(Regex("([0-9])([a-zA-Z])"), "$1 $2") // Add spaces between numbers and letters
-        .replace(Regex("\\s+"), " ") // Normalize multiple spaces
+        .replace(Regex(" +"), " ") // Normalize multiple spaces while preserving newlines
         .trim()
 }


### PR DESCRIPTION
## Summary
- Preserve newlines while normalizing spaces in thinking content
- Normalize spacing for assistant responses using existing formatter

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6893913b58948323b209fd54c25c410a