### PR TITLE
Separate action icons from chat input

### DIFF
--- a/app/src/main/java/com/nervesparks/iris/ui/components/ModernChatInput.kt
+++ b/app/src/main/java/com/nervesparks/iris/ui/components/ModernChatInput.kt
@@ -65,8 +65,10 @@ fun ModernChatInput(
             modifier = Modifier
                 .padding(horizontal = ComponentStyles.defaultPadding, vertical = ComponentStyles.smallPadding)
         ) {
+
             Row(
                 modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.spacedBy(ComponentStyles.smallPadding),
                 verticalAlignment = Alignment.CenterVertically
             ) {
                 ModernIconButton(
@@ -119,7 +121,14 @@ fun ModernChatInput(
                         modifier = Modifier.size(ComponentStyles.defaultIconSize)
                     )
                 }
+            }
 
+            Spacer(modifier = Modifier.height(ComponentStyles.smallPadding))
+
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
                 ThemedChatInputField(
                     value = value,
                     onValueChange = onValueChange,
@@ -145,7 +154,7 @@ fun ModernChatInput(
                         modifier = Modifier
                             .size(ComponentStyles.defaultIconSize)
                             .clip(CircleShape)
-                            .background(MaterialTheme.colorScheme.primary)
+                            .background(MaterialTheme.colorScheme.primary),
                     ) {
                         Icon(
                             imageVector = Icons.Default.Send,
@@ -167,7 +176,6 @@ fun ModernChatInput(
                     }
                 }
             }
-
             if (showAttachmentDialog) {
                 AttachmentBottomSheet(
                     onDismiss = { showAttachmentDialog = false },


### PR DESCRIPTION
## Summary
- split chat input icons into a dedicated row with consistent spacing
- keep text field and send/voice controls in a second row

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68939140ee748323a7d3ef3541b5bb62