### PR TITLE
Add reasoning support flag and conditional thinking rendering

### DIFF
--- a/app/src/main/java/com/nervesparks/iris/MainViewModel.kt
+++ b/app/src/main/java/com/nervesparks/iris/MainViewModel.kt
@@ -109,6 +109,9 @@ class MainViewModel @Inject constructor(
     var showThinkingTokens by mutableStateOf(true)
     var thinkingTokenStyle by mutableStateOf("COLLAPSIBLE") // COLLAPSIBLE, ALWAYS_VISIBLE, HIDDEN
 
+    // Flag indicating if the currently loaded model supports reasoning tokens
+    var supportsReasoning by mutableStateOf(false)
+
     var downloadableModels by mutableStateOf<List<Downloadable>>(emptyList())
         private set
 
@@ -1488,6 +1491,8 @@ class MainViewModel @Inject constructor(
      * Load a model by file path - wrapper for the load method
      */
     fun loadModel(modelPath: String) {
+        val modelName = modelPath.substringAfterLast("/")
+        supportsReasoning = allModels.find { it["name"] == modelName }?.get("supportsReasoning") == "true"
         load(modelPath, modelThreadCount)
     }
     
@@ -1496,6 +1501,7 @@ class MainViewModel @Inject constructor(
      */
     fun loadModelByName(modelName: String, directory: File) {
         Log.d(tag, "Loading model by name: $modelName from directory: ${directory.absolutePath}")
+        supportsReasoning = allModels.find { it["name"] == modelName }?.get("supportsReasoning") == "true"
         val modelFile = File(directory, modelName)
         if (modelFile.exists()) {
             Log.d(tag, "Model file exists at: ${modelFile.absolutePath}")

--- a/app/src/main/java/com/nervesparks/iris/ui/components/ChatSection.kt
+++ b/app/src/main/java/com/nervesparks/iris/ui/components/ChatSection.kt
@@ -47,7 +47,7 @@ fun ChatMessageList(viewModel: MainViewModel, scrollState: LazyListState) {
                     "codeBlock" -> CodeBlockMessage(content)
                     "assistant" -> {
                         val (reasoningContent, _) = ReasoningParser.parse(content)
-                        if (reasoningContent.isNotEmpty() || viewModel.showThinkingTokens) {
+                        if (viewModel.supportsReasoning && reasoningContent.isNotEmpty()) {
                             ThinkingMessage(
                                 message = content,
                                 viewModel = viewModel,

--- a/app/src/main/java/com/nervesparks/iris/ui/components/ThinkingMessage.kt
+++ b/app/src/main/java/com/nervesparks/iris/ui/components/ThinkingMessage.kt
@@ -71,33 +71,32 @@ fun ThinkingMessage(
         Column(
             modifier = Modifier.padding(ComponentStyles.defaultPadding)
         ) {
-            // Header with thinking indicator
-            Row(
-                modifier = Modifier.fillMaxWidth(),
-                verticalAlignment = Alignment.CenterVertically
-            ) {
-                Icon(
-                    imageVector = Icons.Default.Info,
-                    contentDescription = "Thinking",
-                    tint = MaterialTheme.colorScheme.primary,
-                    modifier = Modifier.size(ComponentStyles.defaultIconSize)
-                )
-                
-                Spacer(modifier = Modifier.width(ComponentStyles.smallPadding))
-                
-                Text(
-                    text = "AI Reasoning",
-                    color = MaterialTheme.colorScheme.primary,
-                    style = MaterialTheme.typography.bodyMedium,
-                    fontWeight = FontWeight.Medium
-                )
-                
-                Spacer(modifier = Modifier.weight(1f))
-                
-                // Toggle button - only show if there's thinking content
-                if (thinkingContent.isNotEmpty()) {
+            // Header with thinking indicator - only show when reasoning text exists
+            if (thinkingContent.isNotEmpty()) {
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    Icon(
+                        imageVector = Icons.Default.Info,
+                        contentDescription = "Thinking",
+                        tint = MaterialTheme.colorScheme.primary,
+                        modifier = Modifier.size(ComponentStyles.defaultIconSize)
+                    )
+
+                    Spacer(modifier = Modifier.width(ComponentStyles.smallPadding))
+
+                    Text(
+                        text = "AI Reasoning",
+                        color = MaterialTheme.colorScheme.primary,
+                        style = MaterialTheme.typography.bodyMedium,
+                        fontWeight = FontWeight.Medium
+                    )
+
+                    Spacer(modifier = Modifier.weight(1f))
+
                     IconButton(
-                        onClick = { 
+                        onClick = {
                             isThinkingExpanded = !isThinkingExpanded
                             viewModel.updateShowThinkingTokens(isThinkingExpanded)
                         }


### PR DESCRIPTION
## Summary
- track whether the loaded model supports reasoning tokens
- show reasoning UI only when a reasoning-capable model provides reasoning text
- hide AI Reasoning header when no reasoning content exists

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6893ab49f7f88323b1200bc962716a0a