### PR TITLE
Add progress and validation to quantization screen

### DIFF
--- a/app/src/main/java/com/nervesparks/iris/MainViewModel.kt
+++ b/app/src/main/java/com/nervesparks/iris/MainViewModel.kt
@@ -692,12 +692,13 @@ class MainViewModel @Inject constructor(
         }
     }
 
-    fun quantizeModel(model: String, quantizeType: String) {
-        viewModelScope.launch {
-            val inputFile = File(getApplication<Application>().getExternalFilesDir(null), model)
-            val outputFile = File(getApplication<Application>().getExternalFilesDir(null), "${model.substringBeforeLast(".")}-$quantizeType.gguf")
-            llamaAndroid.quantize(inputFile.absolutePath, outputFile.absolutePath, quantizeType)
-        }
+    suspend fun quantizeModel(model: String, quantizeType: String): Int {
+        val inputFile = File(getApplication<Application>().getExternalFilesDir(null), model)
+        val outputFile = File(
+            getApplication<Application>().getExternalFilesDir(null),
+            "${model.substringBeforeLast(".")}-$quantizeType.gguf"
+        )
+        return llamaAndroid.quantize(inputFile.absolutePath, outputFile.absolutePath, quantizeType)
     }
 
     private var template by mutableStateOf("")


### PR DESCRIPTION
## Summary
- restyle QuantizeScreen using ComponentStyles cards, typography, and spacing
- validate that the selected model exists before quantization and report success or failure
- expose quantizeModel result so the UI can display progress and outcome

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6893ab4483dc8323a08f1e100184bb38