### PR TITLE
Add chat list navigation and search

### DIFF
--- a/app/src/main/java/com/nervesparks/iris/MainViewModel.kt
+++ b/app/src/main/java/com/nervesparks/iris/MainViewModel.kt
@@ -1538,7 +1538,7 @@ class MainViewModel @Inject constructor(
         return input.replace("\\s+".toRegex(), " ")
     }
 
-    private fun persistChat() {
+    fun persistChat() {
         val title = messages.firstOrNull { it["role"] == "user" }?.get("content")?.take(64) ?: "Chat"
         val baseChat = currentChat?.copy(title = title, updated = System.currentTimeMillis())
             ?: Chat(title = title)

--- a/app/src/main/java/com/nervesparks/iris/ui/ChatListScreen.kt
+++ b/app/src/main/java/com/nervesparks/iris/ui/ChatListScreen.kt
@@ -31,6 +31,8 @@ fun ChatListScreen(
 ) {
     val chats by viewModel.chats.collectAsState(initial = emptyList())
     val scope = rememberCoroutineScope()
+    var searchQuery by remember { mutableStateOf("") }
+    val filteredChats = chats.filter { it.title.contains(searchQuery, ignoreCase = true) }
 
     Scaffold(
         floatingActionButton = {
@@ -43,16 +45,26 @@ fun ChatListScreen(
             Modifier
                 .fillMaxSize()
                 .padding(paddingValues)) {
-            if (chats.isEmpty()) {
+            OutlinedTextField(
+                value = searchQuery,
+                onValueChange = { searchQuery = it },
+                placeholder = { Text("Search chats") },
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(16.dp),
+                singleLine = true
+            )
+
+            if (filteredChats.isEmpty()) {
                 Box(Modifier.weight(1f).fillMaxSize(), contentAlignment = Alignment.Center) {
                     Text(
-                        "No chats yet.",
+                        if (chats.isEmpty()) "No chats yet." else "No chats found.",
                         color = MaterialTheme.colorScheme.onSurfaceVariant
                     )
                 }
             } else {
                 LazyColumn(Modifier.weight(1f)) {
-                    items(chats, key = { it.id }) { chat ->
+                    items(filteredChats, key = { it.id }) { chat ->
                         ChatRow(
                             chat = chat,
                             onClick = { onChatSelected(chat.id) },

--- a/app/src/main/java/com/nervesparks/iris/ui/components/TopAppBar.kt
+++ b/app/src/main/java/com/nervesparks/iris/ui/components/TopAppBar.kt
@@ -36,7 +36,8 @@ fun ModernTopAppBar(
     showModelDropdown: Boolean,
     onModelDropdownDismiss: () -> Unit,
     viewModel: MainViewModel,
-    extFilesDir: File?
+    extFilesDir: File?,
+    onChatListClick: (() -> Unit)? = null
 ) {
     TopAppBar(
         title = {
@@ -60,6 +61,17 @@ fun ModernTopAppBar(
             }
         },
         actions = {
+            onChatListClick?.let { click ->
+                ModernIconButton(onClick = click) {
+                    Icon(
+                        imageVector = Icons.Default.List,
+                        contentDescription = "Chats",
+                        tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                        modifier = Modifier.size(ComponentStyles.defaultIconSize)
+                    )
+                }
+            }
+
             // Model selection button
             if (availableModels.isNotEmpty()) {
                 Card(

--- a/app/src/main/java/com/nervesparks/iris/ui/screens/MainChatScreen2.kt
+++ b/app/src/main/java/com/nervesparks/iris/ui/screens/MainChatScreen2.kt
@@ -12,6 +12,7 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.rememberDrawerState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -97,6 +98,12 @@ fun MainChatScreen2(
         }
     }
 
+    DisposableEffect(Unit) {
+        onDispose {
+            viewModel.persistChat()
+        }
+    }
+
     ModalNavigationDrawer(
         drawerState = drawerState,
         drawerContent = {
@@ -133,7 +140,11 @@ fun MainChatScreen2(
                     showModelDropdown = showModelDropdown,
                     onModelDropdownDismiss = { showModelDropdown = false },
                     viewModel = viewModel,
-                    extFilesDir = extFilesDir
+                    extFilesDir = extFilesDir,
+                    onChatListClick = {
+                        viewModel.persistChat()
+                        navController.navigate(AppDestinations.CHAT_LIST)
+                    }
                 )
             },
             content = {


### PR DESCRIPTION
## Summary
- add chat history button to top bar and persist conversations on exit
- implement search bar to filter chats by title

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6893ab3d431c832394d1bfab2764b036