### PR TITLE
Add context length control to parameters screen

### DIFF
--- a/app/src/main/java/com/nervesparks/iris/MainViewModel.kt
+++ b/app/src/main/java/com/nervesparks/iris/MainViewModel.kt
@@ -955,6 +955,7 @@ class MainViewModel @Inject constructor(
                 Log.e("MainViewModel", "Error loading contextLength, using default", e)
                 modelContextLength = 32768  // Increased for Qwen3 support
             }
+            maxContextLimit = modelContextLength
             
             try {
                 modelSystemPrompt = userPreferencesRepository.getModelSystemPrompt()

--- a/app/src/main/java/com/nervesparks/iris/ui/ParametersScreen.kt
+++ b/app/src/main/java/com/nervesparks/iris/ui/ParametersScreen.kt
@@ -177,6 +177,31 @@ fun ParametersScreen(viewModel: MainViewModel) {
                     }
                 }
 
+                item { SectionDivider() }
+
+                item {
+                    SettingSection(
+                        title = "Context Length",
+                        description = "Maximum context window size (512 - 32768)"
+                    ) {
+                        Text(
+                            text = "${viewModel.modelContextLength}",
+                            color = MaterialTheme.colorScheme.onSurface
+                        )
+                        Slider(
+                            value = viewModel.modelContextLength.toFloat(),
+                            onValueChange = { viewModel.modelContextLength = it.toInt() },
+                            valueRange = 512f..32768f,
+                            steps = 63,
+                            colors = SliderDefaults.colors(
+                                thumbColor = MaterialTheme.colorScheme.primary,
+                                activeTrackColor = MaterialTheme.colorScheme.primary,
+                                inactiveTrackColor = MaterialTheme.colorScheme.surfaceVariant
+                            )
+                        )
+                    }
+                }
+
 
             }
         }
@@ -236,6 +261,7 @@ fun ParametersScreen(viewModel: MainViewModel) {
                     if(viewModel.loadedModelName.value == "") {
                         Toast.makeText(context, "Load A Model First", Toast.LENGTH_SHORT).show()
                     } else {
+                        viewModel.updateModelSettings(contextLength = viewModel.modelContextLength)
                         viewModel.currentDownloadable?.destination?.path?.let {
                             viewModel.load(it, viewModel.user_thread.toInt())
                             Toast.makeText(context, "Changes have been saved", Toast.LENGTH_SHORT).show()


### PR DESCRIPTION
## Summary
- Add context length slider bound to `modelContextLength` and persist via `updateModelSettings`.
- Reload context length into `maxContextLimit` when loading model settings for startup.

## Testing
- `./gradlew test` *(fails: SDK location not found)*


------
https://chatgpt.com/codex/tasks/task_e_6893ab3fad2c8323b3a9652e18b9a4b4