### PR TITLE
Implement OCR for images and auto document processing

### DIFF
--- a/app/src/main/java/com/nervesparks/iris/ui/components/DocumentManager.kt
+++ b/app/src/main/java/com/nervesparks/iris/ui/components/DocumentManager.kt
@@ -1,12 +1,12 @@
 package com.nervesparks.iris.ui.components
 
-import android.graphics.BitmapFactory
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.height
 import androidx.compose.material3.Button
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.mutableStateOf
@@ -14,9 +14,6 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
-import com.google.mlkit.vision.common.InputImage
-import com.google.mlkit.vision.text.TextRecognition
-import com.google.mlkit.vision.text.latin.TextRecognizerOptions
 import com.itextpdf.kernel.pdf.PdfDocument
 import com.itextpdf.kernel.pdf.PdfReader
 import com.itextpdf.kernel.pdf.canvas.parser.PdfTextExtractor
@@ -25,31 +22,46 @@ import com.nervesparks.iris.MainViewModel
 @Composable
 fun DocumentManager(viewModel: MainViewModel, modifier: Modifier = Modifier) {
     val context = LocalContext.current
-    val documentText = remember { mutableStateOf<String?>(null) }
+    val errorMessage = remember { mutableStateOf<String?>(null) }
     val launcher = rememberLauncherForActivityResult(ActivityResultContracts.GetContent()) { uri ->
+        errorMessage.value = null
         uri?.let {
-            val text = when (context.contentResolver.getType(it)) {
-                "application/pdf" -> {
-                    val pdfReader = PdfReader(context.contentResolver.openInputStream(it))
-                    val pdfDocument = PdfDocument(pdfReader)
-                    val numPages = pdfDocument.numberOfPages
-                    val stringBuilder = StringBuilder()
-                    for (i in 1..numPages) {
-                        stringBuilder.append(PdfTextExtractor.getTextFromPage(pdfDocument.getPage(i)))
+            try {
+                when (context.contentResolver.getType(it) ?: "") {
+                    "application/pdf" -> {
+                        val pdfReader = PdfReader(context.contentResolver.openInputStream(it))
+                        val pdfDocument = PdfDocument(pdfReader)
+                        val numPages = pdfDocument.numberOfPages
+                        val stringBuilder = StringBuilder()
+                        for (i in 1..numPages) {
+                            stringBuilder.append(
+                                PdfTextExtractor.getTextFromPage(pdfDocument.getPage(i))
+                            )
+                        }
+                        pdfDocument.close()
+                        val text = stringBuilder.toString()
+                        viewModel.indexDocument(text)
+                        viewModel.summarizeDocument(text)
                     }
-                    pdfDocument.close()
-                    stringBuilder.toString()
+                    "image/jpeg", "image/png" -> {
+                        viewModel.sendImage(it)
+                    }
+                    "text/plain" -> {
+                        val text = context.contentResolver.openInputStream(it)?.bufferedReader()
+                            .use { reader -> reader?.readText() }
+                        if (text != null) {
+                            viewModel.indexDocument(text)
+                            viewModel.summarizeDocument(text)
+                        } else {
+                            errorMessage.value = "Failed to read document"
+                        }
+                    }
+                    else -> {
+                        errorMessage.value = "Unsupported file format"
+                    }
                 }
-                "image/jpeg", "image/png" -> {
-                    viewModel.sendImage(it)
-                    null
-                }
-                else -> {
-                    context.contentResolver.openInputStream(it)?.bufferedReader().use { reader -> reader?.readText() }
-                }
-            }
-            if (text != null) {
-                documentText.value = text
+            } catch (e: Exception) {
+                errorMessage.value = "Failed to process document: ${e.message}"
             }
         }
     }
@@ -61,15 +73,9 @@ fun DocumentManager(viewModel: MainViewModel, modifier: Modifier = Modifier) {
         Button(onClick = { launcher.launch("image/*") }) {
             Text("Import Image")
         }
-        documentText.value?.let { text ->
+        errorMessage.value?.let { msg ->
             Spacer(modifier = Modifier.height(8.dp))
-            Button(onClick = { viewModel.indexDocument(text) }) {
-                Text("Embed Document")
-            }
-            Spacer(modifier = Modifier.height(8.dp))
-            Button(onClick = { viewModel.summarizeDocument(text) }) {
-                Text("Summarize Document")
-            }
+            Text(msg, color = MaterialTheme.colorScheme.error)
         }
     }
 }


### PR DESCRIPTION
## Summary
- use ML Kit OCR when sending images and summarize/index extracted text
- automatically index and summarize imported documents
- surface unsupported format and OCR errors to users

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6893ab422b948323a9f421e2c31a8753