### PR TITLE
feat: expose advanced generation controls

### DIFF
--- a/app/src/main/java/com/nervesparks/iris/data/UserPreferencesRepository.kt
+++ b/app/src/main/java/com/nervesparks/iris/data/UserPreferencesRepository.kt
@@ -22,6 +22,7 @@ private const val KEY_MODEL_CONTEXT_LENGTH = "model_context_length"
 private const val KEY_MODEL_SYSTEM_PROMPT = "model_system_prompt"
 private const val KEY_MODEL_CHAT_FORMAT = "model_chat_format"
 private const val KEY_MODEL_THREAD_COUNT = "model_thread_count"
+private const val KEY_MODEL_REPEAT_PENALTY = "model_repeat_penalty"
 private const val KEY_CACHED_MODELS = "cached_models"
 private const val KEY_MODEL_CONFIG_PREFIX = "model_config_"
 
@@ -157,6 +158,14 @@ open class UserPreferencesRepository protected constructor(context: Context) {
         return sharedPreferences.getString(KEY_MODEL_SYSTEM_PROMPT, "You are a helpful AI assistant.") ?: "You are a helpful AI assistant."
     }
 
+    open fun setModelRepeatPenalty(repeatPenalty: Float) {
+        sharedPreferences.edit().putFloat(KEY_MODEL_REPEAT_PENALTY, repeatPenalty).apply()
+    }
+
+    open fun getModelRepeatPenalty(): Float {
+        return sharedPreferences.getFloat(KEY_MODEL_REPEAT_PENALTY, 1.1f)
+    }
+
     open fun setModelChatFormat(chatFormat: String) {
         sharedPreferences.edit().putString(KEY_MODEL_CHAT_FORMAT, chatFormat).apply()
     }
@@ -182,7 +191,9 @@ open class UserPreferencesRepository protected constructor(context: Context) {
             topK = sharedPreferences.getInt(prefix + "top_k", 40),
             threadCount = sharedPreferences.getInt(prefix + "thread_count", 2),
             contextLength = sharedPreferences.getInt(prefix + "context_length", 4096),
-            systemPrompt = sharedPreferences.getString(prefix + "system_prompt", "") ?: ""
+            systemPrompt = sharedPreferences.getString(prefix + "system_prompt", "") ?: "",
+            maxTokens = sharedPreferences.getInt(prefix + "max_tokens", 2048),
+            repeatPenalty = sharedPreferences.getFloat(prefix + "repeat_penalty", 1.1f)
         )
     }
 
@@ -195,6 +206,8 @@ open class UserPreferencesRepository protected constructor(context: Context) {
             putInt(prefix + "thread_count", config.threadCount)
             putInt(prefix + "context_length", config.contextLength)
             putString(prefix + "system_prompt", config.systemPrompt)
+            putInt(prefix + "max_tokens", config.maxTokens)
+            putFloat(prefix + "repeat_penalty", config.repeatPenalty)
             apply()
         }
     }
@@ -332,6 +345,7 @@ open class UserPreferencesRepository protected constructor(context: Context) {
         jsonObject.put("modelMaxTokens", getModelMaxTokens())
         jsonObject.put("modelContextLength", getModelContextLength())
         jsonObject.put("modelSystemPrompt", getModelSystemPrompt())
+        jsonObject.put("modelRepeatPenalty", getModelRepeatPenalty())
         jsonObject.put("modelChatFormat", getModelChatFormat())
         jsonObject.put("modelThreadCount", getModelThreadCount())
         jsonObject.put("showThinkingTokens", getShowThinkingTokens())
@@ -362,6 +376,7 @@ open class UserPreferencesRepository protected constructor(context: Context) {
             if (json.has("modelMaxTokens")) editor.putInt(KEY_MODEL_MAX_TOKENS, json.getInt("modelMaxTokens"))
             if (json.has("modelContextLength")) editor.putInt(KEY_MODEL_CONTEXT_LENGTH, json.getInt("modelContextLength"))
             if (json.has("modelSystemPrompt")) editor.putString(KEY_MODEL_SYSTEM_PROMPT, json.getString("modelSystemPrompt"))
+            if (json.has("modelRepeatPenalty")) editor.putFloat(KEY_MODEL_REPEAT_PENALTY, json.getDouble("modelRepeatPenalty").toFloat())
             if (json.has("modelChatFormat")) editor.putString(KEY_MODEL_CHAT_FORMAT, json.getString("modelChatFormat"))
             if (json.has("modelThreadCount")) editor.putInt(KEY_MODEL_THREAD_COUNT, json.getInt("modelThreadCount"))
             if (json.has("showThinkingTokens")) editor.putBoolean(KEY_SHOW_THINKING_TOKENS, json.getBoolean("showThinkingTokens"))

--- a/app/src/main/java/com/nervesparks/iris/data/repository/ModelRepository.kt
+++ b/app/src/main/java/com/nervesparks/iris/data/repository/ModelRepository.kt
@@ -72,5 +72,7 @@ data class ModelConfiguration(
     val topK: Int = 40,
     val threadCount: Int = 2,
     val contextLength: Int = 4096,
-    val systemPrompt: String = ""
-) 
+    val systemPrompt: String = "",
+    val maxTokens: Int = 2048,
+    val repeatPenalty: Float = 1.1f
+)

--- a/app/src/main/java/com/nervesparks/iris/data/repository/impl/ModelRepositoryImpl.kt
+++ b/app/src/main/java/com/nervesparks/iris/data/repository/impl/ModelRepositoryImpl.kt
@@ -176,12 +176,28 @@ class ModelRepositoryImpl @Inject constructor(
             }
             
             Log.d(tag, "Loading model: $modelPath")
+
+            val threadCount = userPreferencesRepository.getModelThreadCount()
+            val topK = userPreferencesRepository.getModelTopK()
+            val topP = userPreferencesRepository.getModelTopP()
+            val temp = userPreferencesRepository.getModelTemperature()
+            val maxTokens = userPreferencesRepository.getModelMaxTokens()
+            val contextLength = userPreferencesRepository.getModelContextLength()
+            val systemPrompt = userPreferencesRepository.getModelSystemPrompt()
+            val repeatPenalty = userPreferencesRepository.getModelRepeatPenalty()
+
+            Log.d(tag, "Applied settings: threads=$threadCount, topK=$topK, topP=$topP, temp=$temp, maxTokens=$maxTokens, contextLength=$contextLength, repeatPenalty=$repeatPenalty")
+
             llamaAndroid.load(
                 modelPath,
-                userThreads = 2, // Default thread count
-                topK = 40, // Default top-k
-                topP = 0.9f, // Default top-p
-                temp = 0.7f // Default temperature
+                userThreads = threadCount,
+                topK = topK,
+                topP = topP,
+                temp = temp,
+                maxTokens = maxTokens,
+                contextLength = contextLength,
+                systemPrompt = systemPrompt,
+                repeatPenalty = repeatPenalty
             )
             currentLoadedModel = modelFile.name
             Log.i(tag, "Successfully loaded model: $currentLoadedModel")

--- a/app/src/main/java/com/nervesparks/iris/ui/components/ModelSettingsScreen.kt
+++ b/app/src/main/java/com/nervesparks/iris/ui/components/ModelSettingsScreen.kt
@@ -23,6 +23,7 @@ fun ModelSettingsScreen(
     var temperature by remember { mutableStateOf(0.7f) }
     var topP by remember { mutableStateOf(0.9f) }
     var topK by remember { mutableStateOf(40) }
+    var repeatPenalty by remember { mutableStateOf(viewModel.modelRepeatPenalty) }
     var maxTokens by remember { mutableStateOf(2048) }
     var contextLength by remember { mutableStateOf(4096) }
     var systemPrompt by remember { mutableStateOf("You are a helpful AI assistant.") }
@@ -148,9 +149,44 @@ fun ModelSettingsScreen(
                 )
             }
         }
-        
+
         Spacer(modifier = Modifier.height(16.dp))
-        
+
+        // Repeat Penalty Control
+        Card(
+            modifier = Modifier.fillMaxWidth(),
+            colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.secondary),
+            shape = RoundedCornerShape(12.dp)
+        ) {
+            Column(
+                modifier = Modifier.padding(16.dp)
+            ) {
+                Text(
+                    text = "Repeat Penalty: ${String.format("%.2f", repeatPenalty)}",
+                    style = MaterialTheme.typography.titleMedium,
+                    color = MaterialTheme.colorScheme.onSecondary
+                )
+                Text(
+                    text = "Penalize repeated tokens (1.0 = off)",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSecondary.copy(alpha = 0.7f)
+                )
+                Slider(
+                    value = repeatPenalty,
+                    onValueChange = { repeatPenalty = it },
+                    valueRange = 0.5f..2.0f,
+                    steps = 15,
+                    colors = SliderDefaults.colors(
+                        thumbColor = MaterialTheme.colorScheme.tertiary,
+                        activeTrackColor = MaterialTheme.colorScheme.tertiary,
+                        inactiveTrackColor = MaterialTheme.colorScheme.tertiary.copy(alpha = 0.3f)
+                    )
+                )
+            }
+        }
+
+        Spacer(modifier = Modifier.height(16.dp))
+
         // Max Tokens Control
         Card(
             modifier = Modifier.fillMaxWidth(),
@@ -352,7 +388,8 @@ fun ModelSettingsScreen(
                     contextLength = contextLength,
                     systemPrompt = systemPrompt,
                     chatFormat = selectedChatFormat,
-                    threadCount = threadCount
+                    threadCount = threadCount,
+                    repeatPenalty = repeatPenalty
                 )
                 onBackPressed()
             },

--- a/app/src/test/java/com/nervesparks/iris/data/FakeUserPreferencesRepository.kt
+++ b/app/src/test/java/com/nervesparks/iris/data/FakeUserPreferencesRepository.kt
@@ -84,6 +84,14 @@ class FakeUserPreferencesRepository(context: Context) : UserPreferencesRepositor
         return prefs[KEY_MODEL_SYSTEM_PROMPT] as? String ?: "You are a helpful AI assistant."
     }
 
+    override fun setModelRepeatPenalty(repeatPenalty: Float) {
+        prefs[KEY_MODEL_REPEAT_PENALTY] = repeatPenalty
+    }
+
+    override fun getModelRepeatPenalty(): Float {
+        return prefs[KEY_MODEL_REPEAT_PENALTY] as? Float ?: 1.1f
+    }
+
     override fun setModelChatFormat(chatFormat: String) {
         prefs[KEY_MODEL_CHAT_FORMAT] = chatFormat
     }
@@ -108,7 +116,9 @@ class FakeUserPreferencesRepository(context: Context) : UserPreferencesRepositor
             topK = prefs[prefix + "top_k"] as? Int ?: 40,
             threadCount = prefs[prefix + "thread_count"] as? Int ?: 2,
             contextLength = prefs[prefix + "context_length"] as? Int ?: 4096,
-            systemPrompt = prefs[prefix + "system_prompt"] as? String ?: ""
+            systemPrompt = prefs[prefix + "system_prompt"] as? String ?: "",
+            maxTokens = prefs[prefix + "max_tokens"] as? Int ?: 2048,
+            repeatPenalty = prefs[prefix + "repeat_penalty"] as? Float ?: 1.1f
         )
     }
 
@@ -120,6 +130,8 @@ class FakeUserPreferencesRepository(context: Context) : UserPreferencesRepositor
         prefs[prefix + "thread_count"] = config.threadCount
         prefs[prefix + "context_length"] = config.contextLength
         prefs[prefix + "system_prompt"] = config.systemPrompt
+        prefs[prefix + "max_tokens"] = config.maxTokens
+        prefs[prefix + "repeat_penalty"] = config.repeatPenalty
     }
 
     override fun getCachedModels(): String {
@@ -237,6 +249,7 @@ private const val KEY_MODEL_CHAT_FORMAT = "model_chat_format"
 private const val KEY_MODEL_THREAD_COUNT = "model_thread_count"
 private const val KEY_CACHED_MODELS = "cached_models"
 private const val KEY_MODEL_CONFIG_PREFIX = "model_config_"
+private const val KEY_MODEL_REPEAT_PENALTY = "model_repeat_penalty"
 private const val KEY_SHOW_THINKING_TOKENS = "show_thinking_tokens"
 private const val KEY_THINKING_TOKEN_STYLE = "thinking_token_style"
 private const val KEY_UI_THEME = "ui_theme"


### PR DESCRIPTION
## Summary
- extend `LLamaAndroid` to support maxTokens, contextLength, systemPrompt, and repeatPenalty for loading and text generation
- persist and apply new generation settings across the app, including UI controls
- log applied generation settings to simplify debugging

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6893ffec235483238815bfed78ef4d12