### PR TITLE
Handle backend reinit failures

### DIFF
--- a/app/src/main/java/com/nervesparks/iris/MainViewModel.kt
+++ b/app/src/main/java/com/nervesparks/iris/MainViewModel.kt
@@ -2080,10 +2080,16 @@ class MainViewModel @Inject constructor(
     fun selectBackend(backend: String) {
         viewModelScope.launch {
             try {
-                llamaAndroid.setBackend(backend.lowercase())
-                currentBackend = backend
-                backendError = null
-                Log.d(tag, "Backend changed to: $backend")
+                val success = llamaAndroid.setBackend(backend.lowercase())
+                if (success) {
+                    currentBackend = backend
+                    backendError = null
+                    Log.d(tag, "Backend changed to: $backend")
+                } else {
+                    backendError = "Failed to switch backend to $backend"
+                    currentBackend = "CPU"
+                    Log.e(tag, "Backend switch failed, reverted to CPU")
+                }
             } catch (e: Exception) {
                 Log.e(tag, "Failed to set backend to $backend: ${e.message}")
                 backendError = "Failed to switch backend to $backend: ${e.message}"

--- a/llama/src/main/java/android/llama/cpp/LLamaAndroid.kt
+++ b/llama/src/main/java/android/llama/cpp/LLamaAndroid.kt
@@ -131,7 +131,7 @@ class LLamaAndroid {
     private external fun free_context(context: Long)
     private external fun backend_init(numa: Boolean)
     private external fun backend_free()
-    private external fun set_backend(backend: String)
+    private external fun set_backend(backend: String): Boolean
     private external fun new_batch(nTokens: Int, embd: Int, nSeqMax: Int): Long
     private external fun free_batch(batch: Long)
     private external fun new_sampler(top_p: Float, top_k: Int, temp: Float): Long
@@ -276,10 +276,12 @@ class LLamaAndroid {
         return res
     }
     
-    suspend fun setBackend(backend: String) {
+    suspend fun setBackend(backend: String): Boolean {
+        var success = false
         withContext(runLoop) {
-                            set_backend(backend)
+            success = set_backend(backend)
         }
+        return success
     }
     
     suspend fun getMemoryUsage(): Long {


### PR DESCRIPTION
## Summary
- Reinitialize llama backend after environment updates and fall back to CPU if OpenCL init fails
- Return backend init success to Kotlin and let UI handle failure
- Update MainViewModel to react to backend switch failures

## Testing
- `./gradlew build` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_689421537898832382b15c883ec290a7