### PR TITLE
Enable OpenCL support

### DIFF
--- a/llama/build.gradle.kts
+++ b/llama/build.gradle.kts
@@ -20,10 +20,9 @@ android {
                 arguments += "-DLLAMA_BUILD_COMMON=ON"
                 arguments += "-DCMAKE_BUILD_TYPE=Release"
                 arguments += "-DLLAMA_CURL=OFF"
-                                    // OpenCL for Adreno GPUs - temporarily disabled to fix libcutils.so dependency
-                    arguments += "-DGGML_OPENCL=OFF"
-                    // arguments += "-DGGML_OPENCL_USE_ADRENO_KERNELS=ON"
-                    // arguments += "-DGGML_OPENCL_EMBED_KERNELS=ON"
+                // Enable OpenCL with embedded kernels to avoid missing runtime dependencies
+                // arguments += "-DGGML_OPENCL_USE_ADRENO_KERNELS=ON"
+                arguments += "-DGGML_OPENCL_EMBED_KERNELS=ON"
                 cppFlags += listOf()
                 arguments += listOf()
 

--- a/llama/src/main/cpp/CMakeLists.txt
+++ b/llama/src/main/cpp/CMakeLists.txt
@@ -31,13 +31,11 @@ project("llama-android")
 # is preferred for the same purpose.
 #
 
-# OpenCL disabled to avoid libcutils.so dependency issues
 # Configure OpenCL for Android
 if(ANDROID)
-    message(STATUS "OpenCL disabled to avoid dependency issues")
-    set(OpenCL_LIBRARIES "")
-    set(OpenCL_INCLUDE_DIRS "")
-    set(GGML_OPENCL OFF)
+    find_package(OpenCL REQUIRED)
+    set(GGML_OPENCL ON)
+    include_directories(${OpenCL_INCLUDE_DIRS})
 endif()
 
 #load local llama.cpp
@@ -61,6 +59,7 @@ target_link_libraries(${CMAKE_PROJECT_NAME}
         # List libraries link to the target library
         llama
         common
+        ${OpenCL_LIBRARIES}
         android
         log)
 


### PR DESCRIPTION
## Summary
- allow building with OpenCL by embedding kernels in the native build
- configure CMake to discover and link OpenCL libraries

## Testing
- `./gradlew :llama:assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6894215027cc832385369b0637a7aa5e