### PR TITLE
Return error when context window is exceeded

### DIFF
--- a/llama/src/main/cpp/llama-android.cpp
+++ b/llama/src/main/cpp/llama-android.cpp
@@ -745,6 +745,10 @@ Java_android_llama_cpp_LLamaAndroid_completion_1init(
 
     if (n_kv_req > n_ctx) {
         LOGe("error: n_kv_req > n_ctx, the required KV cache size is not big enough");
+        env->ReleaseStringUTFChars(jtext, text);
+        env->ThrowNew(env->FindClass("java/lang/IllegalArgumentException"),
+                      "n_kv_req > n_ctx: reduce prompt length or increase context");
+        return -1;
     }
 
     // Suppress per-token logging to avoid UI jank and high latency


### PR DESCRIPTION
## Summary
- throw an exception and return -1 when `completion_init` requires more KV cache than available
- surface context overflow errors in Kotlin callers and guide the user to reduce prompt length or increase context size

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a602d554d08323ac90aee6d7f63fc6