### PR TITLE
Migrate preferences to encrypted DataStore

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -138,8 +138,8 @@ dependencies {
         exclude(group = "com.google.guava", module = "guava")
     }
 
-    // Security Crypto for encrypted shared preferences
-    implementation("androidx.security:security-crypto:1.0.0")
+    // Security Crypto for encrypted storage
+    implementation("androidx.security:security-crypto:1.1.0-alpha06")
 
     // WorkManager for background tasks
     implementation("androidx.work:work-runtime-ktx:2.9.0") {


### PR DESCRIPTION
## Summary
- replace deprecated `MasterKeys` API with `MasterKey`
- swap `EncryptedSharedPreferences` for an encrypted DataStore implementation
- introduce delegated preference helpers to cut down repetitive get/set code

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a602d2fef083238140a3ab6a1198e9