### PR TITLE
feat: introduce shared search models

### DIFF
--- a/app/src/main/java/com/nervesparks/iris/MainViewModel.kt
+++ b/app/src/main/java/com/nervesparks/iris/MainViewModel.kt
@@ -48,7 +48,7 @@ import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.withContext
 import com.nervesparks.iris.data.WebSearchService
 import com.nervesparks.iris.data.AndroidSearchService
-import com.nervesparks.iris.data.WebSearchService.SearchResult
+import com.nervesparks.iris.data.search.SearchResult
 import com.google.mlkit.vision.common.InputImage
 import com.google.mlkit.vision.text.TextRecognition
 import com.google.mlkit.vision.text.latin.TextRecognizerOptions

--- a/app/src/main/java/com/nervesparks/iris/data/AndroidSearchService.kt
+++ b/app/src/main/java/com/nervesparks/iris/data/AndroidSearchService.kt
@@ -4,6 +4,8 @@ import android.content.Context
 import android.content.Intent
 import android.net.Uri
 import android.util.Log
+import com.nervesparks.iris.data.search.SearchResponse
+import com.nervesparks.iris.data.search.SearchResult
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import java.net.URLEncoder
@@ -14,20 +16,6 @@ import java.net.URLEncoder
  */
 class AndroidSearchService(private val context: Context) {
     private val tag = "AndroidSearchService"
-
-    data class SearchResult(
-        val title: String,
-        val snippet: String,
-        val url: String,
-        val source: String
-    )
-
-    data class SearchResponse(
-        val success: Boolean,
-        val results: List<SearchResult>? = null,
-        val error: String? = null,
-        val query: String = ""
-    )
 
     /**
      * Launch search in user's default browser

--- a/app/src/main/java/com/nervesparks/iris/data/WebSearchService.kt
+++ b/app/src/main/java/com/nervesparks/iris/data/WebSearchService.kt
@@ -1,6 +1,8 @@
 package com.nervesparks.iris.data
 
 import android.util.Log
+import com.nervesparks.iris.data.search.SearchResponse
+import com.nervesparks.iris.data.search.SearchResult
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import okhttp3.OkHttpClient
@@ -13,20 +15,6 @@ class WebSearchService(
     private val userPreferencesRepository: UserPreferencesRepository
 ) {
     private val tag = "WebSearchService"
-
-    data class SearchResult(
-        val title: String,
-        val snippet: String,
-        val url: String,
-        val source: String
-    )
-
-    data class SearchResponse(
-        val success: Boolean,
-        val results: List<SearchResult>? = null,
-        val error: String? = null,
-        val query: String = ""
-    )
 
     /**
      * Perform a web search using Google Custom Search API or fallback to DuckDuckGo

--- a/app/src/main/java/com/nervesparks/iris/data/search/SearchModels.kt
+++ b/app/src/main/java/com/nervesparks/iris/data/search/SearchModels.kt
@@ -1,0 +1,21 @@
+package com.nervesparks.iris.data.search
+
+/**
+ * Represents a single search result item.
+ */
+data class SearchResult(
+    val title: String,
+    val snippet: String,
+    val url: String,
+    val source: String
+)
+
+/**
+ * Wrapper for search responses from various services.
+ */
+data class SearchResponse(
+    val success: Boolean,
+    val results: List<SearchResult>? = null,
+    val error: String? = null,
+    val query: String = ""
+)

--- a/app/src/main/java/com/nervesparks/iris/ui/components/SearchResultCard.kt
+++ b/app/src/main/java/com/nervesparks/iris/ui/components/SearchResultCard.kt
@@ -16,14 +16,14 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import com.nervesparks.iris.data.WebSearchService
+import com.nervesparks.iris.data.search.SearchResult
 import com.nervesparks.iris.ui.theme.ComponentStyles
 import com.nervesparks.iris.ui.theme.SemanticColors
 
 @Composable
 fun SearchResultCard(
-    result: WebSearchService.SearchResult,
-    onResultClick: (WebSearchService.SearchResult) -> Unit = {}
+    result: SearchResult,
+    onResultClick: (SearchResult) -> Unit = {}
 ) {
     val infiniteTransition = rememberInfiniteTransition(label = "search_result")
     
@@ -115,9 +115,9 @@ fun SearchResultCard(
 
 @Composable
 fun SearchResultsSection(
-    results: List<WebSearchService.SearchResult>,
+    results: List<SearchResult>,
     query: String,
-    onResultClick: (WebSearchService.SearchResult) -> Unit = {}
+    onResultClick: (SearchResult) -> Unit = {}
 ) {
     val context = LocalContext.current
     


### PR DESCRIPTION
## Summary
- centralize `SearchResult` and `SearchResponse` models in `com.nervesparks.iris.data.search`
- update Android and web search services to use shared models
- unify consumers and UI components on the new search result data classes

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a602d72c288323be0d0387bfd7536c