### PR TITLE
Add shutdown hook for LLamaAndroid executor

### DIFF
--- a/app/src/main/java/com/nervesparks/iris/IrisStarApplication.kt
+++ b/app/src/main/java/com/nervesparks/iris/IrisStarApplication.kt
@@ -1,6 +1,7 @@
 package com.nervesparks.iris
 
 import android.app.Application
+import android.llama.cpp.LLamaAndroid
 import dagger.hilt.android.HiltAndroidApp
 import timber.log.Timber
 @HiltAndroidApp
@@ -9,5 +10,10 @@ class IrisStarApplication : Application() {
         super.onCreate()
         // Always plant debug tree for now
         Timber.plant(Timber.DebugTree())
+    }
+
+    override fun onTerminate() {
+        super.onTerminate()
+        LLamaAndroid.instance().shutdown()
     }
 }

--- a/app/src/main/java/com/nervesparks/iris/MainViewModel.kt
+++ b/app/src/main/java/com/nervesparks/iris/MainViewModel.kt
@@ -1434,6 +1434,8 @@ class MainViewModel @Inject constructor(
 
             } catch (exc: IllegalStateException) {
                 addMessage("error", exc.message ?: "")
+            } finally {
+                llamaAndroid.shutdown()
             }
         }
     }

--- a/llama/src/main/java/android/llama/cpp/LLamaAndroid.kt
+++ b/llama/src/main/java/android/llama/cpp/LLamaAndroid.kt
@@ -87,8 +87,7 @@ class LLamaAndroid {
         _isMarked.value = false
     }
 
-
-    val runLoop: CoroutineDispatcher = Executors.newSingleThreadExecutor {
+    private val executor = Executors.newSingleThreadExecutor {
         thread(start = false, name = "Llm-RunLoop") {
             Log.d(tag, "Dedicated thread for native code: ${Thread.currentThread().name}")
 
@@ -124,7 +123,13 @@ class LLamaAndroid {
                 Log.e(tag, "Stack trace: ${exception.stackTraceToString()}")
             }
         }
-    }.asCoroutineDispatcher()
+    }
+
+    val runLoop: CoroutineDispatcher = executor.asCoroutineDispatcher()
+
+    fun shutdown() {
+        executor.shutdown()
+    }
 
     private val nlen: Int = 256
     private val context_size: Int = 2048


### PR DESCRIPTION
## Summary
- add a dedicated shutdown method for LLamaAndroid's executor
- call shutdown during MainViewModel cleanup and application termination

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b1fdc87218832396e781dbd889b7d0