### PR TITLE
Release JNI strings in mapListToJSONString

### DIFF
--- a/llama/src/main/cpp/llama-android.cpp
+++ b/llama/src/main/cpp/llama-android.cpp
@@ -159,6 +159,7 @@ std::string mapListToJSONString(JNIEnv *env, jobjectArray allMessages) {
             const char* roleStr = env->GetStringUTFChars((jstring)roleObj, nullptr);
             jsonMsg["role"] = roleStr;
             env->ReleaseStringUTFChars((jstring)roleObj, roleStr);
+            env->DeleteLocalRef(roleObj);
         }
         env->DeleteLocalRef(roleKey);
 
@@ -169,6 +170,7 @@ std::string mapListToJSONString(JNIEnv *env, jobjectArray allMessages) {
             const char* contentStr = env->GetStringUTFChars((jstring)contentObj, nullptr);
             jsonMsg["content"] = contentStr;
             env->ReleaseStringUTFChars((jstring)contentObj, contentStr);
+            env->DeleteLocalRef(contentObj);
         }
         env->DeleteLocalRef(contentKey);
 


### PR DESCRIPTION
## Summary
- Release JNI strings and delete local references in `mapListToJSONString` to avoid leaks

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b1fdcc88388323b32ec2fc046b2e1d