### PR TITLE
refactor: modernize chat list screen

### DIFF
--- a/app/src/main/java/com/nervesparks/iris/ui/ChatListScreen.kt
+++ b/app/src/main/java/com/nervesparks/iris/ui/ChatListScreen.kt
@@ -6,19 +6,23 @@ import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.automirrored.filled.Chat
-import androidx.compose.material.icons.filled.MoreVert
+import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material.icons.filled.MoreVert
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import com.nervesparks.iris.MainViewModel
 import com.nervesparks.iris.data.db.Chat
+import com.nervesparks.iris.ui.components.ModernTopAppBar
+import com.nervesparks.iris.ui.theme.ComponentStyles
+import com.nervesparks.iris.ui.theme.ModernIconButton
+import com.nervesparks.iris.ui.theme.ModernTextField
 import kotlinx.coroutines.launch
 import java.text.SimpleDateFormat
 import java.util.Date
@@ -29,20 +33,32 @@ fun ChatListScreen(
     viewModel: MainViewModel,
     onChatSelected: (Long) -> Unit,
     onNewChat: () -> Unit,
+    onMenuClick: () -> Unit = {},
 ) {
+    val context = LocalContext.current
+    val extFilesDir = context.getExternalFilesDir(null)
     val chats by viewModel.chats.collectAsState(initial = emptyList())
     val scope = rememberCoroutineScope()
     var searchQuery by remember { mutableStateOf("") }
     var showDeleteAllDialog by remember { mutableStateOf(false) }
+    var showModelDropdown by remember { mutableStateOf(false) }
     val filteredChats = chats.filter { it.title.contains(searchQuery, ignoreCase = true) }
 
     Scaffold(
         topBar = {
-            TopAppBar(
-                title = { Text("Chats") },
+            ModernTopAppBar(
+                title = "Chats",
+                onMenuClick = onMenuClick,
+                onModelClick = { showModelDropdown = true },
+                currentModel = viewModel.loadedModelName.value,
+                availableModels = viewModel.allModels.map { it["name"] ?: "" },
+                showModelDropdown = showModelDropdown,
+                onModelDropdownDismiss = { showModelDropdown = false },
+                viewModel = viewModel,
+                extFilesDir = extFilesDir,
                 actions = {
                     if (chats.isNotEmpty()) {
-                        IconButton(onClick = { showDeleteAllDialog = true }) {
+                        ModernIconButton(onClick = { showDeleteAllDialog = true }) {
                             Icon(
                                 imageVector = Icons.Default.Delete,
                                 contentDescription = "Delete All Chats"
@@ -62,13 +78,13 @@ fun ChatListScreen(
             Modifier
                 .fillMaxSize()
                 .padding(paddingValues)) {
-            OutlinedTextField(
+            ModernTextField(
                 value = searchQuery,
                 onValueChange = { searchQuery = it },
                 placeholder = { Text("Search chats") },
                 modifier = Modifier
                     .fillMaxWidth()
-                    .padding(16.dp),
+                    .padding(ComponentStyles.defaultPadding),
                 singleLine = true
             )
 
@@ -99,12 +115,12 @@ fun ChatListScreen(
     if (showDeleteAllDialog) {
         androidx.compose.ui.window.Dialog(onDismissRequest = { showDeleteAllDialog = false }) {
             com.nervesparks.iris.ui.theme.ThemedModalCard {
-                Column(Modifier.padding(com.nervesparks.iris.ui.theme.ComponentStyles.defaultPadding)) {
+                Column(Modifier.padding(ComponentStyles.defaultPadding)) {
                     Text("Delete All Chats", style = MaterialTheme.typography.titleMedium)
-                    Spacer(Modifier.height(com.nervesparks.iris.ui.theme.ComponentStyles.smallPadding))
+                    Spacer(Modifier.height(ComponentStyles.smallPadding))
                     Text("Are you sure you want to delete all chats? This action cannot be undone.")
-                    Spacer(Modifier.height(com.nervesparks.iris.ui.theme.ComponentStyles.defaultPadding))
-                    Row(horizontalArrangement = Arrangement.spacedBy(com.nervesparks.iris.ui.theme.ComponentStyles.defaultSpacing)) {
+                    Spacer(Modifier.height(ComponentStyles.defaultPadding))
+                    Row(horizontalArrangement = Arrangement.spacedBy(ComponentStyles.defaultSpacing)) {
                         TextButton(onClick = { showDeleteAllDialog = false }, modifier = Modifier.weight(1f)) { Text("Cancel") }
                         TextButton(onClick = {
                             scope.launch {
@@ -134,14 +150,14 @@ private fun ChatRow(
     ElevatedCard(
         modifier = modifier
             .fillMaxWidth()
-            .padding(horizontal = 16.dp, vertical = 8.dp)
+            .padding(horizontal = ComponentStyles.defaultPadding, vertical = ComponentStyles.smallPadding)
             .clickable { onClick() },
         elevation = CardDefaults.cardElevation(defaultElevation = 2.dp)
     ) {
         Row(
             modifier = Modifier
                 .fillMaxWidth()
-                .padding(16.dp),
+                .padding(ComponentStyles.defaultPadding),
             verticalAlignment = Alignment.CenterVertically
         ) {
             Icon(
@@ -150,7 +166,7 @@ private fun ChatRow(
                 tint = MaterialTheme.colorScheme.primary,
                 modifier = Modifier.size(24.dp)
             )
-            Spacer(modifier = Modifier.width(16.dp))
+            Spacer(modifier = Modifier.width(ComponentStyles.defaultPadding))
             Column(Modifier.weight(1f)) {
                 Text(
                     text = chat.title,
@@ -184,12 +200,12 @@ private fun ChatRow(
     if (showRename) {
         androidx.compose.ui.window.Dialog(onDismissRequest = { showRename = false }) {
             com.nervesparks.iris.ui.theme.ThemedModalCard {
-                Column(Modifier.padding(com.nervesparks.iris.ui.theme.ComponentStyles.defaultPadding)) {
+                Column(Modifier.padding(ComponentStyles.defaultPadding)) {
                     Text("Rename chat", style = MaterialTheme.typography.titleMedium)
-                    Spacer(Modifier.height(com.nervesparks.iris.ui.theme.ComponentStyles.smallPadding))
-                    OutlinedTextField(value = newTitle, onValueChange = { newTitle = it }, singleLine = true)
-                    Spacer(Modifier.height(com.nervesparks.iris.ui.theme.ComponentStyles.defaultPadding))
-                    Row(horizontalArrangement = Arrangement.spacedBy(com.nervesparks.iris.ui.theme.ComponentStyles.defaultSpacing)) {
+                    Spacer(Modifier.height(ComponentStyles.smallPadding))
+                    ModernTextField(value = newTitle, onValueChange = { newTitle = it }, singleLine = true)
+                    Spacer(Modifier.height(ComponentStyles.defaultPadding))
+                    Row(horizontalArrangement = Arrangement.spacedBy(ComponentStyles.defaultSpacing)) {
                         TextButton(onClick = { showRename = false }, modifier = Modifier.weight(1f)) { Text("Cancel") }
                         TextButton(onClick = {
                             if (newTitle.isNotBlank()) onRename(newTitle.trim())

--- a/app/src/main/java/com/nervesparks/iris/ui/components/TopAppBar.kt
+++ b/app/src/main/java/com/nervesparks/iris/ui/components/TopAppBar.kt
@@ -36,7 +36,8 @@ fun ModernTopAppBar(
     showModelDropdown: Boolean,
     onModelDropdownDismiss: () -> Unit,
     viewModel: MainViewModel,
-    extFilesDir: File?
+    extFilesDir: File?,
+    actions: @Composable RowScope.() -> Unit = {}
 ) {
     TopAppBar(
         title = {
@@ -105,6 +106,7 @@ fun ModernTopAppBar(
                     }
                 }
             }
+            actions()
         },
         colors = TopAppBarDefaults.topAppBarColors(
             containerColor = MaterialTheme.colorScheme.surface,


### PR DESCRIPTION
## Summary
- use `ModernTopAppBar` in ChatListScreen and wire menu, model selector, and delete action
- replace `OutlinedTextField` with `ModernTextField`
- expose `actions` slot on `ModernTopAppBar` and standardize padding constants

## Testing
- `./gradlew build` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bdf53339b483238b5059829e89cb21