### PR TITLE
Ensure screen roots respect system bars

### DIFF
--- a/app/src/main/java/com/nervesparks/iris/ui/AboutScreen.kt
+++ b/app/src/main/java/com/nervesparks/iris/ui/AboutScreen.kt
@@ -8,8 +8,10 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
@@ -36,6 +38,8 @@ fun AboutScreen() {
         modifier = Modifier
             .fillMaxSize()
             .background(MaterialTheme.colorScheme.background)
+            .statusBarsPadding()
+            .navigationBarsPadding()
             .padding(ComponentStyles.defaultPadding)
     ) {
         item {

--- a/app/src/main/java/com/nervesparks/iris/ui/BenchMarkScreen.kt
+++ b/app/src/main/java/com/nervesparks/iris/ui/BenchMarkScreen.kt
@@ -52,6 +52,8 @@ fun BenchMarkScreen(viewModel: MainViewModel) {
             color = MaterialTheme.colorScheme.background,
             modifier = Modifier
                 .fillMaxSize()
+                .statusBarsPadding()
+                .navigationBarsPadding()
                 .padding(innerPadding)
         ) {
             Column(

--- a/app/src/main/java/com/nervesparks/iris/ui/ChatListScreen.kt
+++ b/app/src/main/java/com/nervesparks/iris/ui/ChatListScreen.kt
@@ -61,7 +61,10 @@ fun ChatListScreen(
         Column(
             Modifier
                 .fillMaxSize()
-                .padding(paddingValues)) {
+                .padding(paddingValues)
+                .statusBarsPadding()
+                .navigationBarsPadding()
+    ) {
             OutlinedTextField(
                 value = searchQuery,
                 onValueChange = { searchQuery = it },

--- a/app/src/main/java/com/nervesparks/iris/ui/ModelsScreen.kt
+++ b/app/src/main/java/com/nervesparks/iris/ui/ModelsScreen.kt
@@ -7,10 +7,13 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
@@ -42,7 +45,13 @@ fun ModelsScreen(extFileDir: File?, viewModel: MainViewModel, onSearchResultButt
         viewModel.refresh = false
     }
 
-    Box(modifier = Modifier.background(MaterialTheme.colorScheme.background)) {
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(MaterialTheme.colorScheme.background)
+            .statusBarsPadding()
+            .navigationBarsPadding()
+    ) {
         if (viewModel.showAlert) {
             // Modal dialog to show download options
             LoadingModal(

--- a/app/src/main/java/com/nervesparks/iris/ui/ParametersScreen.kt
+++ b/app/src/main/java/com/nervesparks/iris/ui/ParametersScreen.kt
@@ -9,8 +9,10 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.MaterialTheme
@@ -43,6 +45,8 @@ fun ParametersScreen(viewModel: MainViewModel) {
         modifier = Modifier
             .fillMaxSize()
             .background(MaterialTheme.colorScheme.background)
+            .statusBarsPadding()
+            .navigationBarsPadding()
             .padding(16.dp)
     ) {
 

--- a/app/src/main/java/com/nervesparks/iris/ui/PerformanceMonitorScreen.kt
+++ b/app/src/main/java/com/nervesparks/iris/ui/PerformanceMonitorScreen.kt
@@ -56,6 +56,8 @@ fun PerformanceMonitorScreen(
                 modifier = Modifier
                     .fillMaxSize()
                     .padding(paddingValues)
+                    .statusBarsPadding()
+                    .navigationBarsPadding()
                     .padding(16.dp),
                 verticalArrangement = Arrangement.spacedBy(16.dp)
             ) {

--- a/app/src/main/java/com/nervesparks/iris/ui/SearchResultScreen.kt
+++ b/app/src/main/java/com/nervesparks/iris/ui/SearchResultScreen.kt
@@ -12,8 +12,10 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.foundation.layout.wrapContentSize
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
@@ -95,6 +97,8 @@ fun SearchResultScreen(viewModel: MainViewModel, dm: DownloadManager, extFilesDi
         modifier = Modifier
             .fillMaxSize()
             .background(MaterialTheme.colorScheme.background)
+            .statusBarsPadding()
+            .navigationBarsPadding()
             .padding(16.dp),
     ) {
         if (viewModel.showDownloadInfoModal) {

--- a/app/src/main/java/com/nervesparks/iris/ui/SettingsScreen.kt
+++ b/app/src/main/java/com/nervesparks/iris/ui/SettingsScreen.kt
@@ -68,6 +68,8 @@ fun SettingsScreen(
         modifier = Modifier
             .fillMaxSize()
             .background(MaterialTheme.colorScheme.background)
+            .statusBarsPadding()
+            .navigationBarsPadding()
             .verticalScroll(rememberScrollState())
             .padding(ComponentStyles.defaultPadding),
         verticalArrangement = Arrangement.spacedBy(ComponentStyles.defaultSpacing)

--- a/app/src/main/java/com/nervesparks/iris/ui/ThemeSettingsScreen.kt
+++ b/app/src/main/java/com/nervesparks/iris/ui/ThemeSettingsScreen.kt
@@ -50,6 +50,8 @@ fun ThemeSettingsScreen(
             modifier = Modifier
                 .fillMaxSize()
                 .padding(paddingValues)
+                .statusBarsPadding()
+                .navigationBarsPadding()
                 .padding(16.dp),
             verticalArrangement = Arrangement.spacedBy(16.dp)
         ) {

--- a/app/src/main/java/com/nervesparks/iris/ui/screens/MainChatScreen2.kt
+++ b/app/src/main/java/com/nervesparks/iris/ui/screens/MainChatScreen2.kt
@@ -58,7 +58,12 @@ fun NavDrawer(
     onChatList: () -> Unit,
     viewModel: MainViewModel
 ) {
-    Column(modifier = Modifier.padding(ComponentStyles.defaultPadding)) {
+    Column(
+        modifier = Modifier
+            .statusBarsPadding()
+            .navigationBarsPadding()
+            .padding(ComponentStyles.defaultPadding)
+    ) {
         Text(
             text = "IRIS",
             style = MaterialTheme.typography.headlineSmall,

--- a/app/src/main/java/com/nervesparks/iris/ui/screens/ModernTestScreen.kt
+++ b/app/src/main/java/com/nervesparks/iris/ui/screens/ModernTestScreen.kt
@@ -31,6 +31,8 @@ fun ModernTestScreen(
         modifier = modifier
             .fillMaxSize()
             .background(MaterialTheme.colorScheme.background)
+            .statusBarsPadding()
+            .navigationBarsPadding()
     ) {
         // Modern top app bar
         ModernTopAppBar(

--- a/app/src/main/java/com/nervesparks/iris/ui/screens/QuantizeScreen.kt
+++ b/app/src/main/java/com/nervesparks/iris/ui/screens/QuantizeScreen.kt
@@ -3,8 +3,11 @@ package com.nervesparks.iris.ui.screens
 import android.widget.Toast
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.DropdownMenuItem
@@ -47,7 +50,11 @@ fun QuantizeScreen(
     var showProgress by remember { mutableStateOf(false) }
 
     Column(
-        modifier = Modifier.padding(ComponentStyles.defaultPadding),
+        modifier = Modifier
+            .fillMaxSize()
+            .statusBarsPadding()
+            .navigationBarsPadding()
+            .padding(ComponentStyles.defaultPadding),
         verticalArrangement = Arrangement.spacedBy(ComponentStyles.defaultSpacing)
     ) {
         Text("Select Model", style = MaterialTheme.typography.titleMedium)

--- a/app/src/main/java/com/nervesparks/iris/ui/screens/TemplatesScreen.kt
+++ b/app/src/main/java/com/nervesparks/iris/ui/screens/TemplatesScreen.kt
@@ -38,6 +38,8 @@ fun TemplatesScreen(
             modifier = Modifier
                 .fillMaxSize()
                 .padding(paddingValues)
+                .statusBarsPadding()
+                .navigationBarsPadding()
                 .padding(ComponentStyles.defaultPadding)
         ) {
             // Header


### PR DESCRIPTION
## Summary
- add status and navigation bar padding to screen root layouts
- pad navigation drawer content to avoid system UI overlap

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bdf52337d883238538382d89f1af3a