### PR TITLE
Add stable keys for LazyColumn items

### DIFF
--- a/app/src/main/java/com/nervesparks/iris/ui/AboutScreen.kt
+++ b/app/src/main/java/com/nervesparks/iris/ui/AboutScreen.kt
@@ -55,7 +55,7 @@ fun AboutScreen() {
             SectionHeader(text = "Features")
         }
 
-        items(features) { feature ->
+        items(features, key = { it }) { feature ->
             FeatureItem(feature = feature)
         }
 
@@ -64,7 +64,7 @@ fun AboutScreen() {
             SectionHeader(text = "FAQs")
         }
 
-        items(faqs) { faq ->
+        items(faqs, key = { it.first }) { faq ->
             FaqItem(question = faq.first, answer = faq.second)
         }
     }

--- a/app/src/main/java/com/nervesparks/iris/ui/ModelsScreen.kt
+++ b/app/src/main/java/com/nervesparks/iris/ui/ModelsScreen.kt
@@ -136,7 +136,7 @@ fun ModelsScreen(extFileDir: File?, viewModel: MainViewModel, onSearchResultButt
             }
 
             // Show first three suggested models that support reasoning
-            items(suggestedModels) { model ->
+            items(suggestedModels, key = { it["name"] ?: it["source"] ?: "" }) { model ->
                 extFileDir?.let {
                     model["source"]?.let { source ->
                         ModelCard(
@@ -172,7 +172,7 @@ fun ModelsScreen(extFileDir: File?, viewModel: MainViewModel, onSearchResultButt
             }
 
             // Display all models not in Suggested Models
-            items(viewModel.allModels.filterNot { suggestedModels.contains(it) }) { model ->
+            items(viewModel.allModels.filterNot { suggestedModels.contains(it) }, key = { it["name"] ?: it["source"] ?: "" }) { model ->
                 extFileDir?.let {
                     model["source"]?.let { source ->
                         ModelCard(

--- a/app/src/main/java/com/nervesparks/iris/ui/SearchResultScreen.kt
+++ b/app/src/main/java/com/nervesparks/iris/ui/SearchResultScreen.kt
@@ -294,7 +294,7 @@ fun SearchResultScreen(viewModel: MainViewModel, dm: DownloadManager, extFilesDi
                 contentPadding = PaddingValues(16.dp),
                 verticalArrangement = Arrangement.spacedBy(8.dp)
             ) {
-                items(models) { model ->
+                items(models, key = { it["modelId"] ?: it["modelName"] ?: "" }) { model ->
                     Card(
                         modifier = Modifier
                             .fillMaxWidth()

--- a/app/src/main/java/com/nervesparks/iris/ui/components/DownloadModal.kt
+++ b/app/src/main/java/com/nervesparks/iris/ui/components/DownloadModal.kt
@@ -128,7 +128,7 @@ fun DownloadModal(viewModel: MainViewModel, dm: DownloadManager, models: List<Do
                         models.forEach { model ->
                             Log.d("DownloadModal", "Model: ${model.name}, exists: ${model.destination.exists()}")
                         }
-                        items(filteredModels) { model ->
+                        items(filteredModels, key = { it.name }) { model ->
                             DefaultModelCard(viewModel, dm, model)
                         }
                     }
@@ -243,7 +243,7 @@ fun DownloadModal(viewModel: MainViewModel, dm: DownloadManager, models: List<Do
                                 modifier = Modifier.weight(1f),
                                 verticalArrangement = Arrangement.spacedBy(ComponentStyles.smallPadding)
                             ) {
-                                items(results) { model ->
+                                items(results, key = { it["modelId"] ?: it["modelName"] ?: "" }) { model ->
                                     SearchResultCard(model, dm, context)
                                 }
                             }
@@ -387,7 +387,7 @@ private fun SearchResultCard(model: Map<String, String>, dm: DownloadManager, co
                         modifier = Modifier.height(120.dp),
                         verticalArrangement = Arrangement.spacedBy(ComponentStyles.smallPadding)
                     ) {
-                        items(fileList) { file ->
+                        items(fileList, key = { it }) { file ->
                             ThemedModalCard(
                                 modifier = Modifier.fillMaxWidth()
                             ) {

--- a/app/src/main/java/com/nervesparks/iris/ui/components/ModelSelectionModal.kt
+++ b/app/src/main/java/com/nervesparks/iris/ui/components/ModelSelectionModal.kt
@@ -249,7 +249,7 @@ fun ModelSelectionModal(
                         modifier = Modifier.weight(1f),
                         verticalArrangement = Arrangement.spacedBy(ComponentStyles.smallPadding)
                     ) {
-                        items(filteredModels) { model ->
+                        items(filteredModels, key = { it["name"] ?: "" }) { model ->
                             val modelName = model["name"] ?: ""
                             val isSelected = modelName == selectedModel
                             val isCurrentModel = modelName == viewModel.loadedModelName.value

--- a/app/src/main/java/com/nervesparks/iris/ui/components/TopAppBar.kt
+++ b/app/src/main/java/com/nervesparks/iris/ui/components/TopAppBar.kt
@@ -161,7 +161,7 @@ private fun ModelSelectionDropdown(
                 LazyColumn(
                     verticalArrangement = Arrangement.spacedBy(ComponentStyles.smallPadding)
                 ) {
-                    items(availableModels) { model ->
+                    items(availableModels, key = { it }) { model ->
                         val isCurrentModel = model == currentModel
                         
                         Card(

--- a/app/src/main/java/com/nervesparks/iris/ui/screens/TemplatesScreen.kt
+++ b/app/src/main/java/com/nervesparks/iris/ui/screens/TemplatesScreen.kt
@@ -71,7 +71,7 @@ fun TemplatesScreen(
                 modifier = Modifier.fillMaxWidth(),
                 verticalArrangement = Arrangement.spacedBy(ComponentStyles.smallPadding)
             ) {
-                items(templates) { template ->
+                items(templates, key = { it.id }) { template ->
                     SurfaceCard(
                         modifier = Modifier.fillMaxWidth()
                     ) {


### PR DESCRIPTION
## Summary
- provide stable keys for About and FAQ lists
- key model and template lists by identifiers
- ensure dialogs and dropdowns track items with stable keys

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bdf525cc288323860eda2ba5d15084