### PR TITLE
Add content description to model indicator icon

### DIFF
--- a/app/src/main/java/com/nervesparks/iris/ui/components/TopAppBar.kt
+++ b/app/src/main/java/com/nervesparks/iris/ui/components/TopAppBar.kt
@@ -82,7 +82,7 @@ fun ModernTopAppBar(
                     ) {
                         Icon(
                             imageVector = Icons.Default.Star,
-                            contentDescription = null,
+                            contentDescription = "Current model",
                             tint = MaterialTheme.colorScheme.onSecondaryContainer,
                             modifier = Modifier.size(ComponentStyles.smallIconSize)
                         )


### PR DESCRIPTION
## Summary
- add contentDescription "Current model" to the star icon in the top app bar
- audit other icons with null contentDescription and confirm they are decorative

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bdf52d894083239220eb7ec64ea13f