### PR TITLE
Add input validation and model loading tests with CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,29 @@
+name: CI
+
+on:
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 17
+      - name: Cache Gradle
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
+      - name: Run tests
+        uses: reactivecircus/android-emulator-runner@v2
+        with:
+          api-level: 30
+          script: ./gradlew test connectedAndroidTest

--- a/app/src/androidTest/java/com/nervesparks/iris/viewmodel/ModelLoadingInstrumentedTest.kt
+++ b/app/src/androidTest/java/com/nervesparks/iris/viewmodel/ModelLoadingInstrumentedTest.kt
@@ -1,0 +1,48 @@
+package com.nervesparks.iris.viewmodel
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.Assert.*
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.io.File
+import android.llama.cpp.LLamaAndroid
+import com.nervesparks.iris.data.UserPreferencesRepository
+import com.nervesparks.iris.data.repository.ModelRepository
+
+@RunWith(AndroidJUnit4::class)
+class ModelLoadingInstrumentedTest {
+
+    @Test
+    fun loadAndUnloadModelUpdatesState() {
+        val instrumentation = InstrumentationRegistry.getInstrumentation()
+        val context = instrumentation.targetContext
+        val llama = mockk<LLamaAndroid>(relaxed = true)
+        val userPrefs = mockk<UserPreferencesRepository>(relaxed = true)
+        val modelRepo = mockk<ModelRepository>(relaxed = true)
+        val viewModel = ModelViewModel(llama, userPrefs, modelRepo)
+
+        val dir = context.cacheDir
+        val file = File(dir, "test.gguf")
+        file.writeText("model")
+
+        instrumentation.runOnMainSync {
+            viewModel.loadModelByName(file.name, dir)
+        }
+        instrumentation.waitForIdleSync()
+
+        assertTrue(viewModel.isModelLoaded)
+        assertEquals(file.name, viewModel.currentModelName)
+        verify { llama.load(file.absolutePath, any(), any(), any(), any(), any()) }
+
+        instrumentation.runOnMainSync { viewModel.unloadModel() }
+        instrumentation.waitForIdleSync()
+
+        assertFalse(viewModel.isModelLoaded)
+        assertEquals("", viewModel.currentModelName)
+        verify { llama.unload() }
+    }
+}
+

--- a/app/src/test/java/com/nervesparks/iris/security/InputValidatorTest.kt
+++ b/app/src/test/java/com/nervesparks/iris/security/InputValidatorTest.kt
@@ -1,0 +1,108 @@
+package com.nervesparks.iris.security
+
+import org.junit.Assert.*
+import org.junit.Test
+
+class InputValidatorTest {
+
+    @Test
+    fun apiKeyValidation() {
+        assertTrue(InputValidator.isValidApiKey("valid_api_key_1234567890"))
+        assertFalse(InputValidator.isValidApiKey("short"))
+    }
+
+    @Test
+    fun huggingFaceTokenValidation() {
+        val valid = "hf_" + "a".repeat(40)
+        assertTrue(InputValidator.isValidHuggingFaceToken(valid))
+        assertFalse(InputValidator.isValidHuggingFaceToken("hf_short"))
+    }
+
+    @Test
+    fun usernameValidation() {
+        assertTrue(InputValidator.isValidUsername("user_name-1"))
+        assertFalse(InputValidator.isValidUsername("!"))
+    }
+
+    @Test
+    fun urlValidation() {
+        assertTrue(InputValidator.isValidUrl("https://example.com"))
+        assertFalse(InputValidator.isValidUrl("not a url"))
+    }
+
+    @Test
+    fun emailValidation() {
+        assertTrue(InputValidator.isValidEmail("test@example.com"))
+        assertFalse(InputValidator.isValidEmail("bad-email"))
+    }
+
+    @Test
+    fun sanitizeTextInputRemovesUnsafeCharactersAndLimitsLength() {
+        val dangerous = "<script>alert(\"x\")</script>" + "a".repeat(20000)
+        val sanitized = InputValidator.sanitizeTextInput(dangerous)
+        assertFalse(sanitized.contains("<"))
+        assertFalse(sanitized.contains(">"))
+        assertTrue(sanitized.length <= 10000)
+    }
+
+    @Test
+    fun sanitizeModelNameAllowsSafeCharacters() {
+        val name = "model@name!"
+        val sanitized = InputValidator.sanitizeModelName(name)
+        assertEquals("modelname", sanitized)
+    }
+
+    @Test
+    fun numericValidation() {
+        assertTrue(InputValidator.isValidTemperature(1.0f))
+        assertFalse(InputValidator.isValidTemperature(-0.1f))
+        assertTrue(InputValidator.isValidTopP(0.5f))
+        assertFalse(InputValidator.isValidTopP(1.5f))
+        assertTrue(InputValidator.isValidTopK(50))
+        assertFalse(InputValidator.isValidTopK(0))
+        assertTrue(InputValidator.isValidMaxTokens(1000))
+        assertFalse(InputValidator.isValidMaxTokens(50000))
+        assertTrue(InputValidator.isValidContextLength(1024))
+        assertFalse(InputValidator.isValidContextLength(100))
+    }
+
+    @Test
+    fun filePathValidation() {
+        assertTrue(InputValidator.isValidFilePath("model.gguf"))
+        assertFalse(InputValidator.isValidFilePath("../etc/passwd"))
+    }
+
+    @Test
+    fun validateApiKeyReturnsProperResult() {
+        val invalid = InputValidator.validateApiKey("short")
+        assertFalse(invalid.isValid)
+        assertEquals("Invalid API key format", invalid.errorMessage)
+        val key = "valid_api_key_1234567890"
+        val valid = InputValidator.validateApiKey(key)
+        assertTrue(valid.isValid)
+        assertEquals(key, valid.sanitizedValue)
+    }
+
+    @Test
+    fun validateHuggingFaceTokenReturnsProperResult() {
+        val invalid = InputValidator.validateHuggingFaceToken("hf_short")
+        assertFalse(invalid.isValid)
+        assertEquals("Invalid HuggingFace token format", invalid.errorMessage)
+        val token = "hf_" + "a".repeat(40)
+        val valid = InputValidator.validateHuggingFaceToken(token)
+        assertTrue(valid.isValid)
+        assertEquals(token, valid.sanitizedValue)
+    }
+
+    @Test
+    fun validateUsernameReturnsProperResult() {
+        val invalid = InputValidator.validateUsername("!")
+        assertFalse(invalid.isValid)
+        assertEquals("Username must be 3-50 alphanumeric characters", invalid.errorMessage)
+        val name = "user_name-1"
+        val valid = InputValidator.validateUsername(name)
+        assertTrue(valid.isValid)
+        assertEquals(name, valid.sanitizedValue)
+    }
+}
+


### PR DESCRIPTION
## Summary
- add comprehensive InputValidator unit tests covering multiple valid/invalid cases
- add instrumentation test validating ModelViewModel model loading and unloading
- add GitHub Actions workflow to run unit and instrumentation tests on pull requests

## Testing
- `./gradlew test` (fails: SDK location not found)
- `./gradlew connectedAndroidTest` (fails: SDK location not found)


------
https://chatgpt.com/codex/tasks/task_e_68c1a6143ad083239922264404da552e