### PR TITLE
Add network security config and certificate pinning

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -16,6 +16,7 @@
         android:roundIcon="@drawable/icon"
         android:supportsRtl="true"
         android:theme="@style/Theme.LlamaAndroid"
+        android:networkSecurityConfig="@xml/network_security_config"
         android:windowSplashScreenBackground="#00FF00">
 
 

--- a/app/src/main/java/com/nervesparks/iris/data/network/CertificatePins.kt
+++ b/app/src/main/java/com/nervesparks/iris/data/network/CertificatePins.kt
@@ -1,0 +1,27 @@
+package com.nervesparks.iris.data.network
+
+import okhttp3.CertificatePinner
+
+/**
+ * Provides [CertificatePinner] configured with certificate pins for critical hosts.
+ *
+ * To update the pins, follow the steps in `docs/CERTIFICATE_PINNING.md` and
+ * replace the values below with the new SHA-256 hashes of the certificates.
+ */
+object CertificatePins {
+    private val pins = mapOf(
+        "huggingface.co" to listOf(
+            "sha256/AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=" // Placeholder - update with real pin
+        ),
+        "api.github.com" to listOf(
+            "sha256/AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=" // Placeholder - update with real pin
+        )
+    )
+
+    fun build(): CertificatePinner =
+        CertificatePinner.Builder().apply {
+            pins.forEach { (host, hostPins) ->
+                hostPins.forEach { add(host, it) }
+            }
+        }.build()
+}

--- a/app/src/main/java/com/nervesparks/iris/di/NetworkModule.kt
+++ b/app/src/main/java/com/nervesparks/iris/di/NetworkModule.kt
@@ -8,6 +8,7 @@ import com.nervesparks.iris.data.AndroidSearchService
 import com.nervesparks.iris.data.network.CacheControlInterceptor
 import com.nervesparks.iris.data.network.NetworkConfig
 import com.nervesparks.iris.data.network.RequestDeduplicationInterceptor
+import com.nervesparks.iris.data.network.CertificatePins
 import com.squareup.moshi.Moshi
 import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
 import dagger.Module
@@ -51,20 +52,19 @@ object NetworkModule {
 
     @Provides
     @Singleton
+    fun provideCertificatePinner(): CertificatePinner = CertificatePins.build()
+
+    @Provides
+    @Singleton
     fun provideOkHttpClient(
         @ApplicationContext context: Context,
         config: NetworkConfig,
         dedupe: RequestDeduplicationInterceptor,
-        cacheControlInterceptor: CacheControlInterceptor
+        cacheControlInterceptor: CacheControlInterceptor,
+        certificatePinner: CertificatePinner
     ): OkHttpClient {
         val cacheDir = File(context.cacheDir, "http_cache")
         val cache = Cache(cacheDir, config.cacheSizeBytes)
-
-        // SSL Pinning for security - pin HuggingFace and other critical services
-        val certificatePinner = CertificatePinner.Builder()
-            .add("huggingface.co", "sha256/4a6cPehI7JG911yo0RVYjBwhsBzSnr70kSGTHNuX2xI=") // Example pin - UPDATE WITH REAL PIN
-            .add("api.github.com", "sha256/4a6cPehI7JG911yo0RVYjBwhsBzSnr70kSGTHNuX2xI=") // Example pin - UPDATE WITH REAL PIN
-            .build()
 
         return OkHttpClient.Builder()
             .cache(cache)

--- a/app/src/main/res/xml/network_security_config.xml
+++ b/app/src/main/res/xml/network_security_config.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<network-security-config>
+    <!-- Disallow all cleartext (HTTP) traffic to enforce HTTPS -->
+    <base-config cleartextTrafficPermitted="false" />
+
+    <!--
+    Example domain configuration with certificate pinning.
+    Replace "example.com" and the pin below with your own values.
+    <domain-config>
+        <domain includeSubdomains="true">example.com</domain>
+        <pin-set expiration="2025-01-01">
+            <pin digest="SHA-256">AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=</pin>
+        </pin-set>
+    </domain-config>
+    -->
+</network-security-config>

--- a/docs/CERTIFICATE_PINNING.md
+++ b/docs/CERTIFICATE_PINNING.md
@@ -1,0 +1,17 @@
+# Certificate Pinning
+
+The application pins certificates for critical hosts using OkHttp's [`CertificatePinner`](https://square.github.io/okhttp/features/certificate_pinning/).
+
+## Updating pins
+1. Obtain the SHA-256 hash of the host's certificate public key:
+   ```bash
+   echo | openssl s_client -servername <host> -connect <host>:443 2>/dev/null \
+     | openssl x509 -pubkey -noout \
+     | openssl pkey -pubin -outform DER \
+     | openssl dgst -sha256 -binary \
+     | openssl enc -base64
+   ```
+2. Replace the corresponding entry in `app/src/main/java/com/nervesparks/iris/data/network/CertificatePins.kt` with the new value.
+3. Rebuild the app and ensure network requests succeed.
+
+If a certificate rotates, both the new and previous pins can be included temporarily to avoid service disruption.


### PR DESCRIPTION
## Summary
- Enforce HTTPS via `network_security_config.xml` and reference in manifest
- Provide reusable OkHttp `CertificatePinner` and docs for updating pins

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c1a61768048323896beafb36b5370c