### PR TITLE
Use LruCache-based memory manager and remove manual GC calls

### DIFF
--- a/app/src/main/java/com/nervesparks/iris/MainViewModel.kt
+++ b/app/src/main/java/com/nervesparks/iris/MainViewModel.kt
@@ -2463,11 +2463,11 @@ class MainViewModel @Inject constructor(
                     Log.d(tag, "Cleared message history, kept last $keepCount messages")
                 }
                 
-                // Force garbage collection if memory usage is high
+                // Check memory usage against max memory and log if high
                 val memoryUsage = getMemoryUsage()
-                if (memoryUsage > 500 * 1024 * 1024) { // 500MB threshold
-                    System.gc()
-                    Log.d(tag, "Forced garbage collection due to high memory usage: ${memoryUsage / (1024 * 1024)}MB")
+                val maxMemory = Runtime.getRuntime().maxMemory()
+                if (memoryUsage > maxMemory * 0.8) {
+                    Log.d(tag, "High memory usage: ${memoryUsage / (1024 * 1024)}MB")
                 }
             } catch (e: Exception) {
                 Log.e(tag, "Error optimizing memory", e)

--- a/app/src/test/java/com/nervesparks/iris/performance/SmartMemoryManagerTest.kt
+++ b/app/src/test/java/com/nervesparks/iris/performance/SmartMemoryManagerTest.kt
@@ -1,0 +1,21 @@
+package com.nervesparks.iris.performance
+
+import android.content.ComponentCallbacks2
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class SmartMemoryManagerTest {
+
+    @Test
+    fun onTrimMemoryClearsCache() {
+        val manager = SmartMemoryManager<String, String>(maxSize = 2)
+        manager.put("a", "1")
+        manager.put("b", "2")
+        assertEquals(2, manager.size())
+
+        manager.onTrimMemory(ComponentCallbacks2.TRIM_MEMORY_RUNNING_CRITICAL)
+
+        assertEquals(0, manager.size())
+    }
+}
+


### PR DESCRIPTION
## Summary
- Replace custom `SmartMemoryManager` with an `LruCache`-backed implementation that reacts to `onTrimMemory`
- Drop manual `System.gc()` usage and rely on runtime memory checks
- Add unit test simulating low-memory conditions to verify cache cleanup

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c1a60c6f2483238572f66f2b1d54bc