### PR TITLE
Ensure Hugging Face authorization header uses Bearer prefix

### DIFF
--- a/app/src/main/java/com/nervesparks/iris/data/repository/impl/ModelRepositoryImpl.kt
+++ b/app/src/main/java/com/nervesparks/iris/data/repository/impl/ModelRepositoryImpl.kt
@@ -85,7 +85,11 @@ class ModelRepositoryImpl @Inject constructor(
                 throw ValidationException("Search query cannot be blank")
             }
             
-            val token = userPreferencesRepository.huggingFaceToken.takeIf { it.isNotEmpty() }
+            val token = userPreferencesRepository.huggingFaceToken
+                .takeIf { it.isNotEmpty() }
+                ?.let { storedToken ->
+                    if (storedToken.startsWith("Bearer ")) storedToken else "Bearer $storedToken"
+                }
             val models = huggingFaceApiService.searchModels(searchQuery, token)
             val mapped = models.flatMap { info ->
                 info.siblings.filter { it.filename.endsWith(".gguf") }.map { file ->

--- a/app/src/test/java/com/nervesparks/iris/data/repository/impl/ModelRepositoryImplTest.kt
+++ b/app/src/test/java/com/nervesparks/iris/data/repository/impl/ModelRepositoryImplTest.kt
@@ -1,0 +1,78 @@
+package com.nervesparks.iris.data.repository.impl
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import android.llama.cpp.LLamaAndroid
+import com.nervesparks.iris.data.FakeUserPreferencesRepository
+import com.nervesparks.iris.data.HuggingFaceApiService
+import com.squareup.moshi.Moshi
+import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
+import kotlinx.coroutines.runBlocking
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import retrofit2.Retrofit
+import retrofit2.converter.moshi.MoshiConverterFactory
+
+@RunWith(RobolectricTestRunner::class)
+class ModelRepositoryImplTest {
+
+    private lateinit var context: Context
+    private lateinit var userPreferencesRepository: FakeUserPreferencesRepository
+    private lateinit var apiService: HuggingFaceApiService
+    private lateinit var server: MockWebServer
+    private lateinit var repository: ModelRepositoryImpl
+
+    @Before
+    fun setup() {
+        context = ApplicationProvider.getApplicationContext()
+        userPreferencesRepository = FakeUserPreferencesRepository(context)
+        userPreferencesRepository.clearAll()
+
+        server = MockWebServer()
+        server.start()
+
+        val moshi = Moshi.Builder()
+            .add(KotlinJsonAdapterFactory())
+            .build()
+
+        apiService = Retrofit.Builder()
+            .baseUrl(server.url("/"))
+            .addConverterFactory(MoshiConverterFactory.create(moshi))
+            .build()
+            .create(HuggingFaceApiService::class.java)
+
+        repository = ModelRepositoryImpl(
+            context = context,
+            llamaAndroid = LLamaAndroid(),
+            huggingFaceApiService = apiService,
+            userPreferencesRepository = userPreferencesRepository,
+            moshi = moshi
+        )
+    }
+
+    @After
+    fun tearDown() {
+        server.shutdown()
+        userPreferencesRepository.clearAll()
+    }
+
+    @Test
+    fun refreshAvailableModelsPrefixesBearerToken() = runBlocking {
+        val token = "hf_test_token"
+        userPreferencesRepository.setHuggingFaceToken(token)
+
+        val body = """[{"id":"model1","modelId":"Model 1","downloads":10,"likes":5,"tags":[],"siblings":[]}]"""
+        server.enqueue(MockResponse().setBody(body).setResponseCode(200))
+
+        repository.refreshAvailableModels()
+
+        val request = server.takeRequest()
+        assertEquals("Bearer $token", request.getHeader("Authorization"))
+    }
+}


### PR DESCRIPTION
## Summary
- ensure `ModelRepositoryImpl` wraps stored Hugging Face tokens with a `Bearer ` prefix before invoking Retrofit
- add a Robolectric regression test that verifies `refreshAvailableModels` sends a `Bearer hf_...` authorization header when a token is configured

## Testing
- ./gradlew test *(fails: Android SDK not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cdc1cd27c08323be3231aa8f94bd8a