### PR TITLE
Fix Hilt model dependencies

### DIFF
--- a/app/src/main/java/com/nervesparks/iris/di/AppModule.kt
+++ b/app/src/main/java/com/nervesparks/iris/di/AppModule.kt
@@ -30,8 +30,11 @@ object AppModule {
 
     @Provides
     @Singleton
-    fun provideModelLoader(llamaAndroid: LLamaAndroid): ModelLoader {
-        return ModelLoader(llamaAndroid)
+    fun provideModelLoader(
+        llamaAndroid: LLamaAndroid,
+        modelPerformanceTracker: ModelPerformanceTracker
+    ): ModelLoader {
+        return ModelLoader(llamaAndroid, modelPerformanceTracker)
     }
 
     @Provides

--- a/app/src/main/java/com/nervesparks/iris/di/ViewModelModule.kt
+++ b/app/src/main/java/com/nervesparks/iris/di/ViewModelModule.kt
@@ -29,10 +29,18 @@ object ViewModelModule {
     @ViewModelScoped
     fun provideModelViewModel(
         llamaAndroid: android.llama.cpp.LLamaAndroid,
+        modelLoader: com.nervesparks.iris.llm.ModelLoader,
+        modelPerformanceTracker: com.nervesparks.iris.llm.ModelPerformanceTracker,
         userPreferencesRepository: com.nervesparks.iris.data.UserPreferencesRepository,
         modelRepository: com.nervesparks.iris.data.repository.ModelRepository
     ): ModelViewModel {
-        return ModelViewModel(llamaAndroid, userPreferencesRepository, modelRepository)
+        return ModelViewModel(
+            llamaAndroid,
+            modelLoader,
+            modelPerformanceTracker,
+            userPreferencesRepository,
+            modelRepository
+        )
     }
 
     @Provides

--- a/app/src/main/java/com/nervesparks/iris/viewmodel/ModelViewModel.kt
+++ b/app/src/main/java/com/nervesparks/iris/viewmodel/ModelViewModel.kt
@@ -10,6 +10,7 @@ import androidx.lifecycle.viewModelScope
 import com.nervesparks.iris.Downloadable
 import com.nervesparks.iris.data.UserPreferencesRepository
 import com.nervesparks.iris.data.repository.ModelRepository
+import com.nervesparks.iris.llm.ModelLoader
 import com.nervesparks.iris.llm.ModelPerformanceTracker
 import com.nervesparks.iris.security.InputValidator
 import dagger.hilt.android.lifecycle.HiltViewModel


### PR DESCRIPTION
## Summary
- update AppModule to supply ModelLoader with both LLamaAndroid and ModelPerformanceTracker
- expand the ViewModelModule provider for ModelViewModel to pass the full constructor dependencies
- import ModelLoader in ModelViewModel so the Hilt-injected constructor compiles

## Testing
- ./gradlew assembleDebug *(fails: SDK location not configured in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e417f308ac832385a752f0140ec83d