### PR TITLE
Refine ReasoningParser heuristics and add tests

### DIFF
--- a/app/src/test/java/com/nervesparks/iris/llm/ReasoningParserTest.kt
+++ b/app/src/test/java/com/nervesparks/iris/llm/ReasoningParserTest.kt
@@ -1,0 +1,63 @@
+package com.nervesparks.iris.llm
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ReasoningParserTest {
+
+    @Test
+    fun parseHandlesOpenAIStyleThinkTags() {
+        val message = """
+            <think>
+            I should examine the request carefully and recall relevant information.
+            I'll outline the important context before producing the answer.
+            </think>
+            Final answer: Provide the high-level summary requested by the user.
+        """.trimIndent()
+
+        val (reasoning, answer) = ReasoningParser.parse(message, supportsReasoning = true)
+
+        assertTrue(reasoning.startsWith("I should examine"))
+        assertEquals(
+            "Final answer: Provide the high-level summary requested by the user.",
+            answer
+        )
+    }
+
+    @Test
+    fun parseHandlesDeepSeekStructuredReasoning() {
+        val message = """
+            Thoughts:
+            ```reasoning
+            1. Assess prior examples from the corpus.
+            2. Identify the tone that best aligns with the prompt.
+            ```
+            Answer: Deliver a concise acknowledgement with the selected tone.
+        """.trimIndent()
+
+        val (reasoning, answer) = ReasoningParser.parse(message, supportsReasoning = true)
+
+        assertTrue(reasoning.contains("Assess prior examples"))
+        assertEquals("Answer: Deliver a concise acknowledgement with the selected tone.", answer)
+    }
+
+    @Test
+    fun parseHandlesAnthropicStyleReasoningSections() {
+        val message = """
+            Analysis:
+            Step 1. Consider the ethical framing described by the user.
+            Step 2. Choose wording that is direct but considerate.
+
+            Final response should reassure the user while acknowledging their concerns.
+        """.trimIndent()
+
+        val (reasoning, answer) = ReasoningParser.parse(message, supportsReasoning = true)
+
+        assertTrue(reasoning.contains("Step 1"))
+        assertEquals(
+            "Final response should reassure the user while acknowledging their concerns.",
+            answer
+        )
+    }
+}


### PR DESCRIPTION
## Summary
- replace math-specific reasoning and answer patterns with structural and keyword heuristics that work for arbitrary transcripts
- update answer extraction to fall back to structural sections, code fences, or final sentences when explicit markers are absent
- add unit tests covering reasoning transcripts from multiple model styles to ensure math-specific assumptions are removed

## Testing
- ./gradlew test *(fails: requires local Android SDK configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68e417fbbac48323a69f0f114894fd18